### PR TITLE
Delete the unused prop (isExternal) from the Identicon component

### DIFF
--- a/packages/extension-polkagate/src/components/Address.tsx
+++ b/packages/extension-polkagate/src/components/Address.tsx
@@ -23,7 +23,6 @@ export interface Props {
   children?: React.ReactNode;
   className?: string;
   genesisHash?: string | null;
-  isExternal?: boolean | null;
   isHardware?: boolean | null;
   isHidden?: boolean;
   name?: string | null;
@@ -84,7 +83,7 @@ function recodeAddress(address: string, accounts: AccountWithChildren[], chain: 
 
 const defaultRecoded = { account: null, formatted: null, prefix: 42, type: DEFAULT_TYPE };
 
-function Address({ address, className, genesisHash, isExternal, isHardware, margin = '20px auto', name, width = '92%', showCopy = true, style, type: givenType }: Props): React.ReactElement<Props> {
+function Address({ address, className, genesisHash, isHardware, margin = '20px auto', name, width = '92%', showCopy = true, style, type: givenType }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { accounts } = useContext(AccountContext);
   const accountName = useAccountName(address);
@@ -142,7 +141,6 @@ function Address({ address, className, genesisHash, isExternal, isHardware, marg
           <Identicon
             className='identityIcon'
             iconTheme={theme}
-            isExternal={isExternal}
             // onCopy={_onCopy}
             prefix={prefix}
             size={40}

--- a/packages/extension-polkagate/src/components/Identicon.tsx
+++ b/packages/extension-polkagate/src/components/Identicon.tsx
@@ -3,6 +3,7 @@
 
 import type { IconTheme } from '@polkadot/react-identicon/types';
 import type { RegistrationJudgement } from '@polkadot/types/interfaces';
+import type { ThemeProps } from '../types';
 
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import React from 'react';
@@ -40,6 +41,7 @@ function Identicon ({ className, iconTheme, judgement, onCopy, prefix, size, val
             bgcolor: 'success.main',
             borderRadius: '50%',
             color: 'white',
+            // stroke: 'white',
             fontSize: 0.4 * size,
             left: `${size * 0.6}px`,
             position: 'absolute',
@@ -51,7 +53,7 @@ function Identicon ({ className, iconTheme, judgement, onCopy, prefix, size, val
   );
 }
 
-export default styled(Identicon)(() => `
+export default styled(Identicon)(({ theme }: ThemeProps) => `
   background: rgba(192, 192, 292, 0.25);
   border-radius: 50%;
   display: flex;

--- a/packages/extension-polkagate/src/components/Identicon.tsx
+++ b/packages/extension-polkagate/src/components/Identicon.tsx
@@ -3,7 +3,6 @@
 
 import type { IconTheme } from '@polkadot/react-identicon/types';
 import type { RegistrationJudgement } from '@polkadot/types/interfaces';
-import type { ThemeProps } from '../types';
 
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import React from 'react';
@@ -15,7 +14,6 @@ import { AccountId } from '@polkadot/types/interfaces/runtime';
 interface Props {
   className?: string;
   iconTheme?: IconTheme | string;
-  isExternal?: boolean | null;
   onCopy?: () => void;
   prefix?: number;
   value?: AccountId | string | null;
@@ -23,7 +21,7 @@ interface Props {
   judgement?: RegistrationJudgement[] | null;
 }
 
-function Identicon({ className, iconTheme, judgement, onCopy, prefix, size, value }: Props): React.ReactElement<Props> {
+function Identicon ({ className, iconTheme, judgement, onCopy, prefix, size, value }: Props): React.ReactElement<Props> {
   return (
     <div style={{ position: 'relative' }}>
       <div className={className}>
@@ -42,7 +40,6 @@ function Identicon({ className, iconTheme, judgement, onCopy, prefix, size, valu
             bgcolor: 'success.main',
             borderRadius: '50%',
             color: 'white',
-            // stroke: 'white',
             fontSize: 0.4 * size,
             left: `${size * 0.6}px`,
             position: 'absolute',
@@ -54,7 +51,7 @@ function Identicon({ className, iconTheme, judgement, onCopy, prefix, size, valu
   );
 }
 
-export default styled(Identicon)(({ theme }: ThemeProps) => `
+export default styled(Identicon)(() => `
   background: rgba(192, 192, 292, 0.25);
   border-radius: 50%;
   display: flex;

--- a/packages/extension-polkagate/src/partials/AccMenu.tsx
+++ b/packages/extension-polkagate/src/partials/AccMenu.tsx
@@ -99,7 +99,6 @@ function AccMenu({ address, isExternal, isHardware, isMenuOpen, name, setShowMen
         <Identicon
           className='identityIcon'
           iconTheme={identiconTheme}
-          isExternal={isExternal}
           prefix={prefix}
           size={40}
           value={formatted || address}

--- a/packages/extension-polkagate/src/partials/AccMenuInside.tsx
+++ b/packages/extension-polkagate/src/partials/AccMenuInside.tsx
@@ -83,7 +83,6 @@ function AccMenuInside({ address, isMenuOpen, setShowMenu }: Props): React.React
         <Identicon
           className='identityIcon'
           iconTheme={chain?.icon ?? 'polkadot'}
-          isExternal={account?.isExternal}
           prefix={prefix}
           size={40}
           value={formatted || address}

--- a/packages/extension-polkagate/src/popup/account/Others.tsx
+++ b/packages/extension-polkagate/src/popup/account/Others.tsx
@@ -42,7 +42,6 @@ export default function Others({ address, api, balances, chain, identity, price,
   const identicon = (
     <Identicon
       iconTheme={chain?.icon || 'polkadot'}
-      // isExternal={isExternal}
       judgement={identity?.judgements}
       prefix={chain?.ss58Format ?? 42}
       size={40}

--- a/packages/extension-polkagate/src/popup/import/importLedger/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importLedger/index.tsx
@@ -154,7 +154,6 @@ function ImportLedger(): React.ReactElement {
         <Address
           address={address}
           genesisHash={genesis}
-          isExternal
           isHardware
           name={name}
         />

--- a/packages/extension-polkagate/src/popup/signing/Request/index.tsx
+++ b/packages/extension-polkagate/src/popup/signing/Request/index.tsx
@@ -91,7 +91,6 @@ export default function Request({ account: { accountIndex, addressOffset, isExte
           <Address
             address={json.address}
             genesisHash={json.genesisHash}
-            isExternal={isExternal}
             isHardware={isHardware}
             margin='15px auto'
           />
@@ -140,7 +139,6 @@ export default function Request({ account: { accountIndex, addressOffset, isExte
         <div>
           <Address
             address={address}
-            isExternal={isExternal}
           />
         </div>
         <Bytes


### PR DESCRIPTION
1- The isExternal prop is not used in the Identicon component, therefore, it should be deleted.
2- The isExternal prop in the Address component only used in Identicon component, so this prop deleted too.
3- Affected components changed too.