### PR TITLE
Add observeResize function and implement in ShortAddress component

### DIFF
--- a/packages/extension-polkagate/src/components/ShortAddress.tsx
+++ b/packages/extension-polkagate/src/components/ShortAddress.tsx
@@ -1,12 +1,15 @@
 // Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+/* eslint-disable react/jsx-max-props-per-line */
+
 import { Grid, SxProps, Theme } from '@mui/material';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { AccountId } from '@polkadot/types/interfaces/runtime';
 
 import { SHORT_ADDRESS_CHARACTERS } from '../util/constants';
+import ObserveResize from '../util/ObserveResize';
 import CopyAddressButton from './CopyAddressButton';
 
 interface Props {
@@ -22,6 +25,10 @@ function ShortAddress({ address, clipped = false, charsCount = SHORT_ADDRESS_CHA
   const [charactersCount, setCharactersCount] = useState<number>(1);
   const pRef = useRef(null);
   const cRef = useRef(null);
+
+  const decreaseCharactersCount = useCallback(() => setCharactersCount(charactersCount - 1), [charactersCount]);
+
+  ObserveResize(pRef?.current as unknown as Element, 24, decreaseCharactersCount);
 
   useEffect(() => {
     if (!clipped) {

--- a/packages/extension-polkagate/src/util/ObserveResize.tsx
+++ b/packages/extension-polkagate/src/util/ObserveResize.tsx
@@ -1,0 +1,26 @@
+// Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from 'react';
+
+export default function ObserveResize(element: Element, maxSize: number, onResize: () => void): void {
+  useEffect(() => {
+    if (!element) {
+      return;
+    }
+
+    const handleResize = () => {
+      if (element?.clientHeight > maxSize) {
+        onResize();
+      }
+    };
+
+    const resizeObserver = new ResizeObserver(handleResize);
+
+    resizeObserver.observe(element);
+
+    return () => {
+      resizeObserver.unobserve(element);
+    };
+  }, [element, maxSize, onResize]);
+}


### PR DESCRIPTION
### Works Done
This pull request adds the observeResize utility function. This function observes resize events on an element and triggers a callback when the client height exceeds a specified maximum size.

I have incorporated the observeResize function into the ShortAddress component. This implementation ensures that the displayed address adjusts seamlessly to fit the available space.