### PR TITLE
Add useAccountDisplay hook and update Review components for displaying account identity

### DIFF
--- a/packages/extension-polkagate/src/components/AccountHolderWithProxy.tsx
+++ b/packages/extension-polkagate/src/components/AccountHolderWithProxy.tsx
@@ -31,7 +31,7 @@ function AccountHolderWithProxy ({ address, chain, selectedProxyAddress, showDiv
         <ThroughProxy
           address={selectedProxyAddress}
           chain={chain}
-          style={{ pb: '5px', pt: '10px' }}
+          style={{ pb: '5px' }}
         />
       }
       {showDivider &&

--- a/packages/extension-polkagate/src/hooks/index.ts
+++ b/packages/extension-polkagate/src/hooks/index.ts
@@ -3,6 +3,7 @@
 
 export { default as useAccount } from './useAccount';
 export { default as useReferendum } from './useReferendum';
+export { default as useAccountDisplay } from './useAccountDisplay';
 export { default as useAccountLocks } from './useAccountLocks';
 export { default as useBlockInterval } from './useBlockInterval';
 export { default as useFullscreen } from './useFullscreen';

--- a/packages/extension-polkagate/src/hooks/useAccountDisplay.ts
+++ b/packages/extension-polkagate/src/hooks/useAccountDisplay.ts
@@ -6,19 +6,25 @@ import { useEffect, useState } from 'react';
 import useAccountName from './useAccountName';
 import useMyAccountIdentity from './useMyAccountIdentity';
 
-export default function useAccountDisplay (address: string | undefined): string | undefined {
+export default function useAccountDisplay(address: string | undefined): string | undefined {
   const [name, setName] = useState<string | undefined>();
 
   const accountIdentityName = useMyAccountIdentity(address)?.display;
   const accountName = useAccountName(address);
 
   useEffect(() => {
+    if (!address) {
+      setName(undefined);
+
+      return;
+    }
+
     if (!accountIdentityName && !accountName) {
       return;
     }
 
     setName(accountIdentityName ?? accountName);
-  }, [accountIdentityName, accountName]);
+  }, [accountIdentityName, accountName, address]);
 
   return name;
 }

--- a/packages/extension-polkagate/src/hooks/useAccountDisplay.ts
+++ b/packages/extension-polkagate/src/hooks/useAccountDisplay.ts
@@ -1,0 +1,24 @@
+// Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react';
+
+import useAccountName from './useAccountName';
+import useMyAccountIdentity from './useMyAccountIdentity';
+
+export default function useAccountDisplay (address: string | undefined): string | undefined {
+  const [name, setName] = useState<string | undefined>();
+
+  const accountIdentityName = useMyAccountIdentity(address)?.display;
+  const accountName = useAccountName(address);
+
+  useEffect(() => {
+    if (!accountIdentityName && !accountName) {
+      return;
+    }
+
+    setName(accountIdentityName ?? accountName);
+  }, [accountIdentityName, accountName]);
+
+  return name;
+}

--- a/packages/extension-polkagate/src/hooks/useMyAccountIdentity.ts
+++ b/packages/extension-polkagate/src/hooks/useMyAccountIdentity.ts
@@ -17,7 +17,7 @@ export default function useMyAccountIdentity(address: AccountId | string | undef
   const formatted = useFormatted(address);
   const api = useApi(address);
   const account = useAccount(address);
-  const chainName = useChainName(formatted);
+  const chainName = useChainName(address);
 
   const [info, setInfo] = useState<DeriveAccountInfo | null | undefined>();
   const [oldIdentity, setOldIdentity] = useState<DeriveAccountRegistration | null | undefined>();

--- a/packages/extension-polkagate/src/partials/ThroughProxy.tsx
+++ b/packages/extension-polkagate/src/partials/ThroughProxy.tsx
@@ -8,8 +8,8 @@ import React from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 
-import { Identicon, ShortAddress } from '../components';
-import { useAccountName, useTranslation } from '../hooks';
+import { Identity } from '../components';
+import { useApi, useTranslation } from '../hooks';
 
 interface Props {
   address: string;
@@ -17,57 +17,27 @@ interface Props {
   style?: SxProps<Theme> | undefined;
 }
 
-function ThroughProxy ({ address, chain, style = {} }: Props): React.ReactElement {
+function ThroughProxy({ address, chain, style = {} }: Props): React.ReactElement {
   const { t } = useTranslation();
-  const name = useAccountName(address);
+  const api = useApi(address);
 
   return (
     <Grid alignItems='center' container justifyContent='center' sx={{ fontWeight: 300, letterSpacing: '-0.015em', ...style }}>
       <Grid item sx={{ fontSize: '12px' }} xs={2}>
         {t('Through')}
       </Grid>
-      <Divider
-        orientation='vertical'
-        sx={{
-          bgcolor: 'secondary.main',
-          height: '27px',
-          mb: '1px',
-          mt: '4px',
-          width: '1px'
-        }}
+      <Divider orientation='vertical' sx={{ bgcolor: 'secondary.main', height: '27px', mb: '1px', mt: '4px', width: '1px' }} />
+      <Identity
+        address={address}
+        api={api}
+        chain={chain}
+        identiconSize={28}
+        showSocial={false}
+        // subIdOnly
+        style={{ fontSize: '22px', maxWidth: '65%', px: '8px', width: 'fit-content' }}
+        withShortAddress
       />
-      <Grid alignItems='center' container item justifyContent='center' sx={{ maxWidth: '65%', px: '2px', width: 'fit-content' }}>
-        <Grid alignItems='center' container item justifyContent='center' sx={{ lineHeight: '28px', px: '3px' }}>
-          {chain &&
-            <Grid item>
-              <Identicon
-                iconTheme={chain?.icon || 'polkadot'}
-                prefix={chain?.ss58Format ?? 42}
-                size={25}
-                value={address}
-              />
-            </Grid>
-          }
-          <Grid container item justifyContent='flex-start' sx={{ display: 'block', fontSize: '16px', fontWeight: 400, maxWidth: '80%', overflow: 'hidden', pl: '7px', textOverflow: 'ellipsis', whiteSpace: 'nowrap', width: 'fit-content' }}>
-            <Grid item overflow='hidden' sx={{ lineHeight: '16px' }} textOverflow='ellipsis' whiteSpace='nowrap'>
-              {name}
-            </Grid>
-            <Grid item sx={{ fontSize: '12px', fontWeight: 300, lineHeight: '12px', width: 'fit-content' }}>
-              <ShortAddress address={address} />
-            </Grid>
-          </Grid>
-        </Grid>
-      </Grid>
-      <Divider
-        orientation='vertical'
-        sx={{
-          bgcolor: 'secondary.main',
-          height: '27px',
-          mb: '1px',
-          mt: '4px',
-          width: '1px'
-        }}
-      />
+      <Divider orientation='vertical' sx={{ bgcolor: 'secondary.main', height: '27px', mb: '1px', mt: '4px', width: '1px' }} />
       <Grid item sx={{ fontSize: '12px', fontWeight: 300, textAlign: 'center' }} xs={2}>
         {t('as proxy')}
       </Grid>

--- a/packages/extension-polkagate/src/popup/crowdloans/contribute/Review.tsx
+++ b/packages/extension-polkagate/src/popup/crowdloans/contribute/Review.tsx
@@ -10,7 +10,7 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Divider, Grid, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { ApiPromise } from '@polkadot/api';
 import { LinkOption } from '@polkadot/apps-config/endpoints/types';
@@ -18,8 +18,8 @@ import { AccountId } from '@polkadot/types/interfaces/runtime';
 import keyring from '@polkadot/ui-keyring';
 import { BN } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, ChainLogo, FormatBalance, PasswordUseProxyConfirm, Popup, ShortAddress, Warning } from '../../../components';
-import { useAccountName, useChain, useProxies, useTranslation } from '../../../hooks';
+import { AccountHolderWithProxy, ActionContext, ChainLogo, FormatBalance, PasswordUseProxyConfirm, Popup, ShortAddress, Warning } from '../../../components';
+import { useAccountDisplay, useChain, useProxies, useTranslation } from '../../../hooks';
 import { Confirmation, HeaderBrand, SubTitle, ThroughProxy, WaitScreen } from '../../../partials';
 import { broadcast } from '../../../util/api';
 import { Crowdloan, Proxy, ProxyItem, TxInfo } from '../../../util/types';
@@ -48,8 +48,7 @@ export default function Review({ api, contributionAmount, crowdloanToContribute,
   const address = getSubstrateAddress(formatted);
   const chain = useChain(formatted);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
-  const name = useAccountName(formatted);
+  const name = useAccountDisplay(address);
   const proxies = useProxies(api, formatted);
 
   const contribute = api && api.tx.crowdloan.contribute;
@@ -64,7 +63,7 @@ export default function Review({ api, contributionAmount, crowdloanToContribute,
   const [showCrowdloanInfo, setShowCrowdloanInfo] = useState<boolean>(false);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const getName = useCallback((paraId: string): string | undefined => (crowdloansId?.find((e) => e?.paraId === Number(paraId))?.text as string), [crowdloansId]);
 
@@ -100,7 +99,7 @@ export default function Review({ api, contributionAmount, crowdloanToContribute,
         date: Date.now(),
         failureText,
         fee: fee || String(estimatedFee || 0),
-        from: { address: String(from), name: selectedProxyName || name },
+        from: { address: String(from), name },
         subAction: 'Contribute',
         success,
         throughProxy: selectedProxyAddress ? { address: selectedProxyAddress, name: selectedProxyName } : undefined,
@@ -188,7 +187,7 @@ export default function Review({ api, contributionAmount, crowdloanToContribute,
           api={api}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={goContribute}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/governance/delegate/Review.tsx
+++ b/packages/extension-polkagate/src/popup/governance/delegate/Review.tsx
@@ -11,21 +11,21 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import keyring from '@polkadot/ui-keyring';
 
-import { AccountContext, Identity, Motion, ShowValue, WrongPasswordAlert } from '../../../components';
-import { useAccountInfo, useAccountName, useApi, useChain, useDecimal, useToken, useTracks, useTranslation } from '../../../hooks';
+import { Identity, Motion, ShowValue, WrongPasswordAlert } from '../../../components';
+import { useAccountDisplay, useAccountInfo, useApi, useChain, useDecimal, useToken, useTracks, useTranslation } from '../../../hooks';
 import { ThroughProxy } from '../../../partials';
 import { signAndSend } from '../../../util/api';
 import { Proxy, ProxyItem, TxInfo } from '../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../util/utils';
 import PasswordWithTwoButtonsAndUseProxy from '../components/PasswordWithTwoButtonsAndUseProxy';
 import DisplayValue from '../post/castVote/partial/DisplayValue';
+import { GOVERNANCE_PROXY } from '../utils/consts';
 import TracksList from './partial/tracksList';
 import { DelegateInformation, STEPS } from '.';
-import { GOVERNANCE_PROXY } from '../utils/consts';
 
 interface Props {
   address: string | undefined;
@@ -45,19 +45,18 @@ export default function Review({ address, delegateInformation, estimatedFee, for
   const { t } = useTranslation();
   const decimal = useDecimal(address);
   const token = useToken(address);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const api = useApi(address);
   const chain = useChain(address);
   const ref = useRef(null);
   const { tracks } = useTracks(address);
   const delegateeName = useAccountInfo(api, delegateInformation.delegateeAddress)?.identity.display;
-  const { accounts } = useContext(AccountContext);
 
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const delegate = api && api.tx.convictionVoting.delegate;
   const batch = api && api.tx.utility.batchAll;

--- a/packages/extension-polkagate/src/popup/governance/delegate/modify/ModifyDelegate.tsx
+++ b/packages/extension-polkagate/src/popup/governance/delegate/modify/ModifyDelegate.tsx
@@ -11,15 +11,15 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { ISubmittableResult } from '@polkadot/types/types';
 import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, Identity, Motion, ShowValue, WrongPasswordAlert } from '../../../../components';
-import { useAccountInfo, useAccountName, useApi, useChain, useCurrentBlockNumber, useDecimal, useToken, useTracks, useTranslation } from '../../../../hooks';
+import { Identity, Motion, ShowValue, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useAccountInfo, useApi, useChain, useCurrentBlockNumber, useDecimal, useToken, useTracks, useTranslation } from '../../../../hooks';
 import { Lock } from '../../../../hooks/useAccountLocks';
 import { ThroughProxy } from '../../../../partials';
 import { signAndSend } from '../../../../util/api';
@@ -27,10 +27,10 @@ import { BalancesInfo, Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, amountToMachine, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import PasswordWithTwoButtonsAndUseProxy from '../../components/PasswordWithTwoButtonsAndUseProxy';
 import DisplayValue from '../../post/castVote/partial/DisplayValue';
-import TracksList from '../partial/tracksList';
-import { AlreadyDelegateInformation, DelegateInformation, STEPS } from '..';
-import Modify from './modify';
 import { GOVERNANCE_PROXY } from '../../utils/consts';
+import TracksList from '../partial/TracksList';
+import { AlreadyDelegateInformation, DelegateInformation, STEPS } from '..';
+import Modify from './Modify';
 
 interface Props {
   address: string | undefined;
@@ -59,8 +59,7 @@ export default function ModifyDelegate({ accountLocks, address, balances, classi
   const { t } = useTranslation();
   const decimal = useDecimal(address);
   const token = useToken(address);
-  const name = useAccountName(address);
-  const { accounts } = useContext(AccountContext);
+  const name = useAccountDisplay(address);
   const api = useApi(address);
   const chain = useChain(address);
   const { tracks } = useTracks(address);
@@ -86,7 +85,7 @@ export default function ModifyDelegate({ accountLocks, address, balances, classi
   const [newConviction, setNewConviction] = useState<number | undefined>();
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const undelegate = api && api.tx.convictionVoting.undelegate;
   const delegate = api && api.tx.convictionVoting.delegate;

--- a/packages/extension-polkagate/src/popup/governance/delegate/remove/RemoveDelegate.tsx
+++ b/packages/extension-polkagate/src/popup/governance/delegate/remove/RemoveDelegate.tsx
@@ -11,23 +11,23 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import keyring from '@polkadot/ui-keyring';
 import { BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, Identity, Motion, ShowValue, WrongPasswordAlert } from '../../../../components';
-import { useAccountInfo, useAccountName, useApi, useChain, useDecimal, useToken, useTracks, useTranslation } from '../../../../hooks';
+import { Identity, Motion, ShowValue, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useAccountInfo, useApi, useChain, useDecimal, useToken, useTracks, useTranslation } from '../../../../hooks';
 import { ThroughProxy } from '../../../../partials';
 import { signAndSend } from '../../../../util/api';
 import { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import PasswordWithTwoButtonsAndUseProxy from '../../components/PasswordWithTwoButtonsAndUseProxy';
 import DisplayValue from '../../post/castVote/partial/DisplayValue';
-import ReferendaTable from '../partial/ReferendaTable';
-import TracksList from '../partial/tracksList';
-import { AlreadyDelegateInformation, DelegateInformation, STEPS } from '..';
 import { GOVERNANCE_PROXY } from '../../utils/consts';
+import ReferendaTable from '../partial/ReferendaTable';
+import TracksList from '../partial/TracksList';
+import { AlreadyDelegateInformation, DelegateInformation, STEPS } from '..';
 
 interface Props {
   address: string | undefined;
@@ -47,8 +47,7 @@ export default function RemoveDelegate({ address, classicDelegateInformation, fo
   const { t } = useTranslation();
   const decimal = useDecimal(address);
   const token = useToken(address);
-  const name = useAccountName(address);
-  const { accounts } = useContext(AccountContext);
+  const name = useAccountDisplay(address);
   const api = useApi(address);
   const chain = useChain(address);
   const { tracks } = useTracks(address);
@@ -65,7 +64,7 @@ export default function RemoveDelegate({ address, classicDelegateInformation, fo
   const [estimatedFee, setEstimatedFee] = useState<Balance>();
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const undelegate = api && api.tx.convictionVoting.undelegate;
   const batch = api && api.tx.utility.batchAll;

--- a/packages/extension-polkagate/src/popup/governance/post/castVote/Review.tsx
+++ b/packages/extension-polkagate/src/popup/governance/post/castVote/Review.tsx
@@ -12,14 +12,14 @@ import type { Balance } from '@polkadot/types/interfaces';
 
 import { Check as CheckIcon, Close as CloseIcon, RemoveCircle as AbstainIcon } from '@mui/icons-material';
 import { Grid, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { SubmittableExtrinsicFunction } from '@polkadot/api/types';
 import keyring from '@polkadot/ui-keyring';
 import { BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, Identity, Motion, ShortAddress, ShowBalance, ShowValue, Warning, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useApi, useChain, useDecimal, useToken, useTranslation } from '../../../../hooks';
+import { Identity, Motion, ShowBalance, ShowValue, Warning, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useApi, useChain, useDecimal, useToken, useTranslation } from '../../../../hooks';
 import { ThroughProxy } from '../../../../partials';
 import broadcast from '../../../../util/api/broadcast';
 import { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
@@ -48,8 +48,7 @@ export default function Review({ address, estimatedFee, formatted, proxyItems, s
   const { t } = useTranslation();
   const decimal = useDecimal(address);
   const token = useToken(address);
-  const name = useAccountName(address);
-  const { accounts } = useContext(AccountContext);
+  const name = useAccountDisplay(address);
   const theme = useTheme();
   const api = useApi(address);
   const chain = useChain(address);
@@ -60,7 +59,7 @@ export default function Review({ address, estimatedFee, formatted, proxyItems, s
   const [modalHeight, setModalHeight] = useState<number | undefined>();
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
   const isOngoing = !ENDED_STATUSES.includes(status);
 
   const VoteStatus = ({ vote }: { vote: 'Aye' | 'Nay' | 'Abstain' }) => {

--- a/packages/extension-polkagate/src/popup/governance/post/decisionDeposit/index.tsx
+++ b/packages/extension-polkagate/src/popup/governance/post/decisionDeposit/index.tsx
@@ -7,15 +7,15 @@ import type { Balance } from '@polkadot/types/interfaces';
 
 import { Close as CloseIcon } from '@mui/icons-material';
 import { Grid, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { AccountsStore } from '@polkadot/extension-base/stores';
 import keyring from '@polkadot/ui-keyring';
 import { BN_ONE } from '@polkadot/util';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
-import { AccountContext, Identity, ShowBalance, Warning } from '../../../../components';
-import { useAccountName, useApi, useBalances, useChain, useDecimal, useFormatted, useProxies, useToken, useTranslation } from '../../../../hooks';
+import { Identity, ShowBalance, Warning } from '../../../../components';
+import { useAccountDisplay, useApi, useBalances, useChain, useDecimal, useFormatted, useProxies, useToken, useTranslation } from '../../../../hooks';
 import { ThroughProxy } from '../../../../partials';
 import { broadcast } from '../../../../util/api';
 import { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
@@ -24,10 +24,10 @@ import { DraggableModal } from '../../components/DraggableModal';
 import PasswordWithTwoButtonsAndUseProxy from '../../components/PasswordWithTwoButtonsAndUseProxy';
 import SelectProxyModal from '../../components/SelectProxyModal';
 import WaitScreen from '../../partials/WaitScreen';
+import { GOVERNANCE_PROXY } from '../../utils/consts';
 import { Track } from '../../utils/types';
 import DisplayValue from '../castVote/partial/DisplayValue';
 import Confirmation from './Confirmation';
-import { GOVERNANCE_PROXY } from '../../utils/consts';
 
 interface Props {
   address: string | undefined;
@@ -53,9 +53,8 @@ export default function DecisionDeposit({ address, open, refIndex, setOpen, trac
   const decimal = useDecimal(address);
   const token = useToken(address);
   const theme = useTheme();
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const balances = useBalances(address);
-  const { accounts } = useContext(AccountContext);
   const proxies = useProxies(api, formatted);
 
   const proxyItems = useMemo(() =>
@@ -72,7 +71,7 @@ export default function DecisionDeposit({ address, open, refIndex, setOpen, trac
   const tx = api && api.tx.referenda.placeDecisionDeposit;
   const amount = track?.[1]?.decisionDeposit;
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   useEffect(() => {
     if (!formatted || !tx) {

--- a/packages/extension-polkagate/src/popup/manageProxies/Review.tsx
+++ b/packages/extension-polkagate/src/popup/manageProxies/Review.tsx
@@ -14,8 +14,8 @@ import { Chain } from '@polkadot/extension-chains/types';
 import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ONE } from '@polkadot/util';
 
-import { AccountContext, ActionContext, PasswordUseProxyConfirm, ProxyTable, ShowBalance, WrongPasswordAlert } from '../../components';
-import { useAccount, useAccountName } from '../../hooks';
+import { ActionContext, PasswordUseProxyConfirm, ProxyTable, ShowBalance, WrongPasswordAlert } from '../../components';
+import { useAccount, useAccountDisplay } from '../../hooks';
 import useTranslation from '../../hooks/useTranslation';
 import { SubTitle, WaitScreen } from '../../partials';
 import Confirmation from '../../partials/Confirmation';
@@ -34,11 +34,10 @@ interface Props {
 
 export default function Review({ address, api, chain, depositValue, proxies }: Props): React.ReactElement {
   const { t } = useTranslation();
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const account = useAccount(address);
   const onAction = useContext(ActionContext);
 
-  const { accounts } = useContext(AccountContext);
   const [helperText, setHelperText] = useState<string | undefined>();
   const [proxiesToChange, setProxiesToChange] = useState<ProxyItem[] | undefined>();
   const [estimatedFee, setEstimatedFee] = useState<Balance | undefined>();
@@ -51,7 +50,7 @@ export default function Review({ address, api, chain, depositValue, proxies }: P
 
   const formatted = getFormattedAddress(address, undefined, chain.ss58Format);
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
   const removeProxy = api.tx.proxy.removeProxy; /** (delegate, proxyType, delay) **/
   const addProxy = api.tx.proxy.addProxy; /** (delegate, proxyType, delay) **/
   const batchAll = api.tx.utility.batchAll;
@@ -197,7 +196,7 @@ export default function Review({ address, api, chain, depositValue, proxies }: P
         estimatedFee={estimatedFee}
         genesisHash={account?.genesisHash}
         isPasswordError={isPasswordError}
-        label={`${t<string>('Password')} for ${selectedProxyName || account?.name}`}
+        label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
         onChange={setPassword}
         onConfirmClick={onNext}
         proxiedAddress={address}

--- a/packages/extension-polkagate/src/popup/send/Review.tsx
+++ b/packages/extension-polkagate/src/popup/send/Review.tsx
@@ -13,14 +13,14 @@ import type { SubmittableExtrinsicFunction } from '@polkadot/api/types';
 import type { AnyTuple } from '@polkadot/types/types';
 
 import { Container, Divider, Grid } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, Identicon, Motion, PasswordUseProxyConfirm, Popup, ShortAddress, WrongPasswordAlert } from '../../components';
-import { useAccountName, useDecimal, useFormatted, useProxies, useToken, useTranslation } from '../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, Identicon, Motion, PasswordUseProxyConfirm, Popup, ShortAddress, WrongPasswordAlert } from '../../components';
+import { useAccountDisplay, useDecimal, useFormatted, useProxies, useToken, useTranslation } from '../../hooks';
 import { HeaderBrand, WaitScreen } from '../../partials';
 import Confirmation from '../../partials/Confirmation';
 import SubTitle from '../../partials/SubTitle';
@@ -80,9 +80,8 @@ export default function Review({ address, amount, api, chain, estimatedFee, reci
   const proxies = useProxies(api, formatted);
   const decimal = useDecimal(address);
   const token = useToken(address);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
 
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
@@ -93,7 +92,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, reci
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const goToMyAccounts = useCallback(() => {
     onAction('/');
@@ -209,7 +208,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, reci
           confirmText={t<string>('Send')}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={send}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/partial/SelectValidatorsReview.tsx
+++ b/packages/extension-polkagate/src/popup/staking/partial/SelectValidatorsReview.tsx
@@ -18,8 +18,8 @@ import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ONE } from '@polkadot/util';
 
-import { AccountContext, ActionContext, Motion, PasswordUseProxyConfirm, Popup, ShowValue, WrongPasswordAlert } from '../../../components';
-import { useAccountName, useChain, useDecimal, useFormatted, useProxies, useToken, useTranslation } from '../../../hooks';
+import { ActionContext, Motion, PasswordUseProxyConfirm, Popup, ShowValue, WrongPasswordAlert } from '../../../components';
+import { useAccountDisplay, useChain, useDecimal, useFormatted, useProxies, useToken, useTranslation } from '../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../partials';
 import Confirmation from '../../../partials/Confirmation';
 import broadcast from '../../../util/api/broadcast';
@@ -47,9 +47,8 @@ export default function Review({ address, allValidatorsIdentities, api, newSelec
   const proxies = useProxies(api, formatted);
   const token = useToken(address);
   const decimal = useDecimal(address);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -67,7 +66,7 @@ export default function Review({ address, allValidatorsIdentities, api, newSelec
   }, [newSelectedValidators, poolId]);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const goToStakingHome = useCallback(() => {
     setShow(false);
@@ -188,7 +187,7 @@ export default function Review({ address, allValidatorsIdentities, api, newSelec
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={nominate}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/pool/myPool/SetState.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/myPool/SetState.tsx
@@ -6,7 +6,7 @@
 import type { ApiPromise } from '@polkadot/api';
 
 import { Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 import { Balance } from '@polkadot/types/interfaces';
@@ -14,8 +14,8 @@ import { AccountId } from '@polkadot/types/interfaces/runtime';
 import keyring from '@polkadot/ui-keyring';
 import { BN_ONE } from '@polkadot/util';
 
-import { AccountContext, ActionContext, Motion, PasswordUseProxyConfirm, Popup, ShortAddress, ShowBalance, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useProxies, useTranslation } from '../../../../hooks';
+import { ActionContext, Motion, PasswordUseProxyConfirm, Popup, ShortAddress, ShowBalance, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useProxies, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, ThroughProxy, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
@@ -40,9 +40,8 @@ interface Props {
 export default function SetState({ address, api, chain, formatted, headerText, helperText, pool, setRefresh, setShow, show, state }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -52,7 +51,7 @@ export default function SetState({ address, api, chain, formatted, headerText, h
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const [estimatedFee, setEstimatedFee] = useState<Balance>();
 
@@ -190,7 +189,7 @@ export default function SetState({ address, api, chain, formatted, headerText, h
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={changeState}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/pool/myPool/editPool/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/myPool/editPool/Review.tsx
@@ -6,7 +6,7 @@
 import type { ApiPromise } from '@polkadot/api';
 
 import { Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { Chain } from '@polkadot/extension-chains/types';
@@ -14,8 +14,8 @@ import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, ActionContext, Infotip, PasswordUseProxyConfirm, Popup, ShowValue, WrongPasswordAlert } from '../../../../../components';
-import { useAccountName, useProxies, useTranslation } from '../../../../../hooks';
+import { ActionContext, Infotip, PasswordUseProxyConfirm, Popup, ShowValue, WrongPasswordAlert } from '../../../../../components';
+import { useAccountDisplay, useProxies, useTranslation } from '../../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import Confirmation from '../../../../../partials/Confirmation';
 import { signAndSend } from '../../../../../util/api';
@@ -42,9 +42,8 @@ interface Props {
 export default function Review({ address, api, chain, changes, formatted, pool, setRefresh, setShow, setShowMyPool, show, state }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -54,7 +53,7 @@ export default function Review({ address, api, chain, changes, formatted, pool, 
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const [estimatedFee, setEstimatedFee] = useState<Balance>();
   const [txCalls, setTxCalls] = useState<SubmittableExtrinsic<'promise'>[]>();
@@ -228,7 +227,7 @@ export default function Review({ address, api, chain, changes, formatted, pool, 
         estimatedFee={estimatedFee}
         genesisHash={chain?.genesisHash}
         isPasswordError={isPasswordError}
-        label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+        label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
         onChange={setPassword}
         onConfirmClick={goEditPool}
         proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/pool/myPool/removeAll/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/myPool/removeAll/Review.tsx
@@ -6,7 +6,7 @@
 import type { ApiPromise } from '@polkadot/api';
 
 import { Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { Chain } from '@polkadot/extension-chains/types';
@@ -14,8 +14,8 @@ import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ONE } from '@polkadot/util';
 
-import { AccountContext, ActionContext, Motion, PasswordUseProxyConfirm, Popup, ShortAddress, ShowBalance, WrongPasswordAlert } from '../../../../../components';
-import { useAccountName, useProxies, useTranslation } from '../../../../../hooks';
+import { ActionContext, Motion, PasswordUseProxyConfirm, Popup, ShortAddress, ShowBalance, WrongPasswordAlert } from '../../../../../components';
+import { useAccountDisplay, useProxies, useTranslation } from '../../../../../hooks';
 import { HeaderBrand, SubTitle, ThroughProxy, WaitScreen } from '../../../../../partials';
 import Confirmation from '../../../../../partials/Confirmation';
 import { signAndSend } from '../../../../../util/api';
@@ -40,9 +40,8 @@ interface Props {
 export default function Review({ address, api, chain, formatted, mode, pool, poolMembers, setRefresh, setShow, setShowMyPool, show }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -54,7 +53,7 @@ export default function Review({ address, api, chain, formatted, mode, pool, poo
   const [membersToRemoveAll, setMembersToRemoveAll] = useState<MemberPoints[] | undefined>();
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const [estimatedFee, setEstimatedFee] = useState<Balance>();
   const [txCalls, setTxCalls] = useState<SubmittableExtrinsic<'promise'>[]>();
@@ -253,7 +252,7 @@ export default function Review({ address, api, chain, formatted, mode, pool, poo
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={unstakeOrRemoveAll}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/pool/nominations/remove/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/nominations/remove/index.tsx
@@ -17,8 +17,8 @@ import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN_ONE } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, Motion, PasswordUseProxyConfirm, Popup, ShowValue, WrongPasswordAlert } from '../../../../../components';
-import { useAccountName, useProxies, useTranslation } from '../../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, Motion, PasswordUseProxyConfirm, Popup, ShowValue, WrongPasswordAlert } from '../../../../../components';
+import { useAccountDisplay, useProxies, useTranslation } from '../../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import Confirmation from '../../../../../partials/Confirmation';
 import broadcast from '../../../../../util/api/broadcast';
@@ -40,9 +40,8 @@ interface Props {
 export default function RemoveValidators({ address, api, chain, formatted, poolId, setShow, show, title }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -56,7 +55,7 @@ export default function RemoveValidators({ address, api, chain, formatted, poolI
   const params = useMemo(() => [poolId], [poolId]);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const goToStakingHome = useCallback(() => {
     setShow(false);
@@ -169,7 +168,7 @@ export default function RemoveValidators({ address, api, chain, formatted, poolI
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           proxiedAddress={formatted}
           proxies={proxyItems}

--- a/packages/extension-polkagate/src/popup/staking/pool/redeem/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/redeem/index.tsx
@@ -9,15 +9,15 @@
 import type { ApiPromise } from '@polkadot/api';
 
 import { Container } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useProxies, useTranslation } from '../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useProxies, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
@@ -40,9 +40,8 @@ interface Props {
 export default function RedeemableWithdrawReview({ address, amount, api, available, chain, formatted, setRefresh, setShow, show }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -53,7 +52,8 @@ export default function RedeemableWithdrawReview({ address, amount, api, availab
   const [estimatedFee, setEstimatedFee] = useState<Balance>();
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
+
   const tx = api.tx.nominationPools.withdrawUnbonded;
 
   const decimal = api.registry.chainDecimals[0];
@@ -181,7 +181,7 @@ export default function RedeemableWithdrawReview({ address, amount, api, availab
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={submit}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/pool/rewards/Stake.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/rewards/Stake.tsx
@@ -16,8 +16,8 @@ import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useProxies, useTranslation } from '../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useProxies, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
@@ -40,9 +40,8 @@ interface Props {
 export default function RewardsStakeReview({ address, amount, api, chain, formatted, setRefresh, setShow, show, staked }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -53,7 +52,7 @@ export default function RewardsStakeReview({ address, amount, api, chain, format
   const [estimatedFee, setEstimatedFee] = useState<Balance>();
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
   const tx = api.tx.nominationPools.bondExtra;
   const params = useMemo(() => ['Rewards'], []);
   const decimal = api.registry.chainDecimals[0];
@@ -175,7 +174,7 @@ export default function RewardsStakeReview({ address, amount, api, chain, format
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={submit}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/pool/rewards/Withdraw.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/rewards/Withdraw.tsx
@@ -9,15 +9,15 @@
 import type { ApiPromise } from '@polkadot/api';
 
 import { Container } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useProxies, useTranslation } from '../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useProxies, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
@@ -40,9 +40,8 @@ interface Props {
 export default function RewardsWithdrawReview({ address, amount, api, available, chain, formatted, setRefresh, setShow, show }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -53,7 +52,7 @@ export default function RewardsWithdrawReview({ address, amount, api, available,
   const [estimatedFee, setEstimatedFee] = useState<Balance>();
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
   const tx = api.tx.nominationPools.claimPayout;
   const params = [];
 
@@ -176,7 +175,7 @@ export default function RewardsWithdrawReview({ address, amount, api, available,
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={submit}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/bondExtra/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/bondExtra/Review.tsx
@@ -1,6 +1,8 @@
 // Copyright 2019-2023 @polkadot/extension-polkadot authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+/* eslint-disable react/jsx-max-props-per-line */
+
 /**
  * @description
  * this component opens bondExtra review page
@@ -9,14 +11,14 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { ApiPromise } from '@polkadot/api';
 import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../../components';
-import { useAccountName, useChain, useFormatted, useProxies, useTranslation } from '../../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../../components';
+import { useAccountDisplay, useChain, useFormatted, useProxies, useTranslation } from '../../../../../hooks';
 import { Confirmation, HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import { broadcast } from '../../../../../util/api';
 import { MyPoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../../util/types';
@@ -37,9 +39,8 @@ export default function Review({ address, api, bondAmount, estimatedFee, pool, s
   const { t } = useTranslation();
   const chain = useChain(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const formatted = useFormatted(address);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const proxies = useProxies(api, address);
   const decimals = api.registry.chainDecimals[0];
 
@@ -52,7 +53,7 @@ export default function Review({ address, api, bondAmount, estimatedFee, pool, s
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
   const totalStaked = new BN(pool.member.points).isZero() ? BN_ZERO : (new BN(pool.member.points).mul(new BN(pool.stashIdAccount.stakingLedger.active))).div(new BN(pool.bondedPool.points));
   const bondExtra = api.tx.nominationPools.bondExtra;
 
@@ -169,7 +170,7 @@ export default function Review({ address, api, bondAmount, estimatedFee, pool, s
           api={api}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={BondExtra}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/createPool/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/createPool/Review.tsx
@@ -11,14 +11,14 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { ApiPromise } from '@polkadot/api';
 import keyring from '@polkadot/ui-keyring';
 import { BN } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, FormatBalance, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../../components';
-import { useAccountName, useChain, useDecimal, useFormatted, useProxies, useTranslation } from '../../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, FormatBalance, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../../components';
+import { useAccountDisplay, useChain, useDecimal, useFormatted, useProxies, useTranslation } from '../../../../../hooks';
 import { Confirmation, HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import { createPool } from '../../../../../util/api';
 import { PoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../../util/types';
@@ -40,9 +40,8 @@ export default function Review({ address, api, createAmount, estimatedFee, poolT
   const { t } = useTranslation();
   const chain = useChain(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const formatted = useFormatted(address);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const proxies = useProxies(api, address);
   const decimal = useDecimal(address);
 
@@ -57,7 +56,7 @@ export default function Review({ address, api, createAmount, estimatedFee, poolT
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const _onBackClick = useCallback(() => {
     setShowReview(false);
@@ -173,7 +172,7 @@ export default function Review({ address, api, createAmount, estimatedFee, poolT
           api={api}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={goCreatePool}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/joinPool/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/joinPool/Review.tsx
@@ -1,6 +1,8 @@
 // Copyright 2019-2023 @polkadot/extension-polkadot authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+/* eslint-disable react/jsx-max-props-per-line */
+
 /**
  * @description
  * this component opens join pool review page
@@ -9,14 +11,14 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { ApiPromise } from '@polkadot/api';
 import keyring from '@polkadot/ui-keyring';
 import { BN } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, ChainLogo, FormatBalance, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../../components';
-import { useAccountName, useChain, useFormatted, useProxies, useTranslation } from '../../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, ChainLogo, FormatBalance, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../../components';
+import { useAccountDisplay, useChain, useFormatted, useProxies, useTranslation } from '../../../../../hooks';
 import { Confirmation, HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import { broadcast } from '../../../../../util/api';
 import { PoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../../util/types';
@@ -38,9 +40,8 @@ export default function Review({ address, api, estimatedFee, joinAmount, poolToJ
   const { t } = useTranslation();
   const chain = useChain(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const formatted = useFormatted(address);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const proxies = useProxies(api, address);
   const decimals = api.registry.chainDecimals[0];
 
@@ -55,7 +56,7 @@ export default function Review({ address, api, estimatedFee, joinAmount, poolToJ
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const _onBackClick = useCallback(() => {
     setShowReview(!showReview);
@@ -172,7 +173,7 @@ export default function Review({ address, api, estimatedFee, joinAmount, poolToJ
           api={api}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={joinPool}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/pool/unstake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/unstake/Review.tsx
@@ -11,15 +11,15 @@ import type { SubmittableExtrinsicFunction } from '@polkadot/api/types';
 import type { AnyTuple } from '@polkadot/types/types';
 
 import { Container, Grid } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useDecimal, useProxies, useToken, useTranslation } from '../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useDecimal, useProxies, useToken, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
@@ -51,11 +51,10 @@ interface Props {
 export default function Review({ address, amount, api, chain, estimatedFee, formatted, maxUnlockingChunks, pool, poolWithdrawUnbonded, redeemDate, setShow, show, total, unbonded, unlockingLen, unstakeAllAmount }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const token = useToken(address);
   const decimal = useDecimal(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -67,7 +66,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, form
   const poolId = pool.poolId
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const goToStakingHome = useCallback(() => {
     setShow(false);
@@ -219,7 +218,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, form
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={unstake}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/solo/fastUnstake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/fastUnstake/Review.tsx
@@ -9,7 +9,7 @@
 import type { ApiPromise } from '@polkadot/api';
 
 import { Container, Grid, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 import { Balance } from '@polkadot/types/interfaces';
@@ -17,8 +17,8 @@ import { AccountId } from '@polkadot/types/interfaces/runtime';
 import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, Warning } from '../../../../components';
-import { useAccountName, useDecimal, useProxies, useTranslation } from '../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, Warning } from '../../../../components';
+import { useAccountDisplay, useDecimal, useProxies, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
@@ -40,10 +40,9 @@ interface Props {
 export default function FastUnstakeReview({ address, amount, api, available, chain, formatted, setShow, show }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(String(address));
   const theme = useTheme();
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const decimal = useDecimal(address);
 
   const [password, setPassword] = useState<string | undefined>();
@@ -56,7 +55,7 @@ export default function FastUnstakeReview({ address, amount, api, available, cha
   const [estimatedFee, setEstimatedFee] = useState<Balance>();
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
   const tx = api.tx.fastUnstake.registerFastUnstake;
 
   const goToStakingHome = useCallback(() => {
@@ -187,7 +186,7 @@ export default function FastUnstakeReview({ address, amount, api, available, cha
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={submit}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/solo/nominations/remove/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/nominations/remove/index.tsx
@@ -9,7 +9,7 @@
  * */
 
 import { Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { ApiPromise } from '@polkadot/api';
 import { Chain } from '@polkadot/extension-chains/types';
@@ -17,8 +17,8 @@ import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN_ONE } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, Motion, PasswordUseProxyConfirm, Popup, ShowValue, WrongPasswordAlert } from '../../../../../components';
-import { useAccountName, useProxies, useTranslation } from '../../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, Motion, PasswordUseProxyConfirm, Popup, ShowValue, WrongPasswordAlert } from '../../../../../components';
+import { useAccountDisplay, useProxies, useTranslation } from '../../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import Confirmation from '../../../../../partials/Confirmation';
 import broadcast from '../../../../../util/api/broadcast';
@@ -39,9 +39,8 @@ interface Props {
 export default function RemoveValidators({ address, api, chain, formatted, setShow, show, title }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -54,7 +53,7 @@ export default function RemoveValidators({ address, api, chain, formatted, setSh
   const chilled = api && api.tx.staking.chill;
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const goToStakingHome = useCallback(() => {
     setShow(false);
@@ -168,7 +167,7 @@ export default function RemoveValidators({ address, api, chain, formatted, setSh
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={remove}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/solo/redeem/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/redeem/index.tsx
@@ -9,7 +9,7 @@
 import type { ApiPromise } from '@polkadot/api';
 
 import { Container } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 import { Balance } from '@polkadot/types/interfaces';
@@ -17,8 +17,8 @@ import { AccountId } from '@polkadot/types/interfaces/runtime';
 import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useProxies, useTranslation } from '../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useProxies, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
@@ -41,9 +41,8 @@ interface Props {
 export default function RedeemableWithdrawReview({ address, amount, api, available, chain, formatted, setRefresh, setShow, show }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(String(address));
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -54,7 +53,7 @@ export default function RedeemableWithdrawReview({ address, amount, api, availab
   const [estimatedFee, setEstimatedFee] = useState<Balance>();
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
   const tx = api.tx.staking.withdrawUnbonded; // sign by controller
 
   const decimal = api.registry.chainDecimals[0];
@@ -183,7 +182,7 @@ export default function RedeemableWithdrawReview({ address, amount, api, availab
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={submit}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/solo/restake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/restake/Review.tsx
@@ -11,20 +11,20 @@ import type { SubmittableExtrinsicFunction } from '@polkadot/api/types';
 import type { AnyTuple } from '@polkadot/types/types';
 
 import { Container } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useDecimal, useProxies, useToken, useTranslation } from '../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useDecimal, useProxies, useToken, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
 import { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
-import { amountToHuman, amountToMachine, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
+import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './partials/TxDetail';
 
 interface Props {
@@ -44,11 +44,10 @@ interface Props {
 export default function Review({ address, amount, api, chain, estimatedFee, formatted, rebonded, setShow, show, total }: Props): React.ReactElement {
   const { t } = useTranslation();
   const decimal = useDecimal(address);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const proxies = useProxies(api, formatted);
   const token = useToken(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
 
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
@@ -60,7 +59,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, form
   const amountInHuman = amountToHuman(amount, decimal);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const goToStakingHome = useCallback(() => {
     setShow(false);
@@ -175,7 +174,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, form
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={unstake}
           proxiedAddress={formatted}

--- a/packages/extension-polkagate/src/popup/staking/solo/settings/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/settings/Review.tsx
@@ -20,8 +20,8 @@ import { ISubmittableResult } from '@polkadot/types/types';
 import keyring from '@polkadot/ui-keyring';
 import { BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AccountContext, ActionContext, Identity, Motion, PasswordUseProxyConfirm, Popup, ShortAddress, ShowValue, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useChain, useFormatted, useProxies, useTranslation } from '../../../../hooks';
+import { ActionContext, Identity, Motion, PasswordUseProxyConfirm, Popup, ShortAddress, ShowValue, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useChain, useFormatted, useProxies, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
@@ -74,11 +74,10 @@ function RewardsDestination({ chain, newSettings, settings }: { settings: SoloSe
 export default function Review({ address, api, newSettings, setRefresh, setShow, setShowSettings, settings, show }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, settings.stashId);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const chain = useChain(address);
   const formatted = useFormatted(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -95,7 +94,7 @@ export default function Review({ address, api, newSettings, setRefresh, setShow,
   const isControllerDeprecated = setController ? setController.meta.args.length === 0 : undefined;
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   useEffect(() => {
     if (!setController || !setPayee || !api || !batchAll || !formatted) {
@@ -238,7 +237,7 @@ export default function Review({ address, api, newSettings, setRefresh, setShow,
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={applySettings}
           proxiedAddress={settings.stashId}

--- a/packages/extension-polkagate/src/popup/staking/solo/stake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/stake/Review.tsx
@@ -14,7 +14,7 @@ import type { AnyTuple } from '@polkadot/types/types';
 
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { Container, Divider, Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 import { Balance } from '@polkadot/types/interfaces';
@@ -22,8 +22,8 @@ import { AccountId } from '@polkadot/types/interfaces/runtime';
 import keyring from '@polkadot/ui-keyring';
 import { BN } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Identity, Infotip, Motion, PasswordUseProxyConfirm, Popup, ShortAddress, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useFormatted, useProxies, useToken, useTranslation } from '../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Identity, Infotip, Motion, PasswordUseProxyConfirm, Popup, ShortAddress, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useFormatted, useProxies, useToken, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
@@ -53,11 +53,10 @@ interface Props {
 export default function Review({ address, amount, api, chain, estimatedFee, isFirstTimeStaking, params, selectedValidators, setShow, settings, show, total, tx }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, settings.stashId);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const token = useToken(address);
   const formatted = useFormatted(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -68,7 +67,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, isFi
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const goToStakingHome = useCallback(() => {
     setShow(false);
@@ -232,7 +231,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, isFi
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={stake}
           proxiedAddress={settings.stashId}

--- a/packages/extension-polkagate/src/popup/staking/solo/tuneUp/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/tuneUp/index.tsx
@@ -10,7 +10,7 @@
 
 import { Divider, Grid, Link } from '@mui/material';
 import Typography from '@mui/material/Typography';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { useLocation } from 'react-router-dom';
 
@@ -19,8 +19,8 @@ import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN_ONE } from '@polkadot/util';
 
-import { AccountContext, ActionContext, Motion, PasswordUseProxyConfirm, Progress, ShortAddress, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useApi, useChain, useChainName, useFormatted, useNeedsPutInFrontOf, useNeedsRebag, useProxies, useTranslation } from '../../../../hooks';
+import { ActionContext, Motion, PasswordUseProxyConfirm, Progress, ShortAddress, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useApi, useChain, useChainName, useFormatted, useNeedsPutInFrontOf, useNeedsRebag, useProxies, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
@@ -28,7 +28,6 @@ import getLogo from '../../../../util/getLogo';
 import { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './TxDetail';
-
 
 export default function TuneUp(): React.ReactElement {
   const { t } = useTranslation();
@@ -46,9 +45,8 @@ export default function TuneUp(): React.ReactElement {
   const rebagInfo = useNeedsRebag(address);
 
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
 
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -59,7 +57,7 @@ export default function TuneUp(): React.ReactElement {
   const [estimatedFee, setEstimatedFee] = useState<Balance>();
 
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
   const rebaged = api && api.tx.voterList.rebag;
   const putInFrontOf = api && api.tx.voterList.putInFrontOf;
 
@@ -214,7 +212,7 @@ export default function TuneUp(): React.ReactElement {
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={submit}
           proxiedAddress={selectedProxyAddress}

--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/Review.tsx
@@ -11,15 +11,15 @@ import type { SubmittableExtrinsicFunction } from '@polkadot/api/types';
 import type { AnyTuple } from '@polkadot/types/types';
 
 import { Container, Grid } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
 import { Balance } from '@polkadot/types/interfaces';
 import keyring from '@polkadot/ui-keyring';
 import { BN } from '@polkadot/util';
 
-import { AccountContext, AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
-import { useAccountName, useProxies, useTranslation } from '../../../../hooks';
+import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
+import { useAccountDisplay, useProxies, useTranslation } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
@@ -51,9 +51,8 @@ interface Props {
 export default function Review({ address, amount, api, chain, chilled, estimatedFee, formatted, hasNominator, maxUnlockingChunks, redeem, redeemDate, setShow, show, staked, total, unbonded, unlockingLen }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
-  const name = useAccountName(address);
+  const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
-  const { accounts } = useContext(AccountContext);
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();
@@ -65,7 +64,7 @@ export default function Review({ address, amount, api, chain, chilled, estimated
   const decimal = api?.registry?.chainDecimals[0] ?? 1;
   const token = api?.registry?.chainTokens[0] ?? '';
   const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
-  const selectedProxyName = useMemo(() => accounts?.find((a) => a.address === getSubstrateAddress(selectedProxyAddress))?.name, [accounts, selectedProxyAddress]);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxyAddress));
 
   const goToStakingHome = useCallback(() => {
     setShow(false);
@@ -200,7 +199,7 @@ export default function Review({ address, amount, api, chain, chilled, estimated
           estimatedFee={estimatedFee}
           genesisHash={chain?.genesisHash}
           isPasswordError={isPasswordError}
-          label={`${t<string>('Password')} for ${selectedProxyName || name}`}
+          label={`${t<string>('Password')} for ${selectedProxyName || name || ''}`}
           onChange={setPassword}
           onConfirmClick={unstake}
           proxiedAddress={formatted}


### PR DESCRIPTION
### Works Done:

1. Added **useAccountDisplay** hook, which combines **useAccountName** and **useMyAccountIdentity** hooks. It accepts the "address" parameter and returns the account name from the extension or the identity name if available.

2. Utilized **useAccountDisplay** hook to retrieve the name for both the **account holder** and **selectedProxyAddress**.

3. Updated Review components to incorporate **useAccountDisplay** for displaying the account identity.

4. Fixed mistakenly passing **formatted** instead of **address** to **useChainName** hook in **useMyAccountIdentity.ts**


_These changes ensure consistent display of the account identity wherever it is required._