### PR TITLE
 Fix recipient name display in transaction details

### DIFF
--- a/packages/extension-polkagate/src/popup/send/Review.tsx
+++ b/packages/extension-polkagate/src/popup/send/Review.tsx
@@ -142,7 +142,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, reci
         subAction: 'Send',
         success,
         throughProxy: selectedProxyAddress ? { address: selectedProxyAddress, name: selectedProxyName } : undefined,
-        to: { address: recipientAddress, name: selectedProxyName || recipientName },
+        to: { address: recipientAddress, name: recipientName },
         txHash: txHash || ''
       };
 


### PR DESCRIPTION
Fixes mistaken display of selected proxy name instead of recipient name in transaction details.

**_Before:_**
![image](https://github.com/PolkaGate/polkagate-extension/assets/75857984/00843db5-8e11-43e1-a86f-786586bc2d15)



**_After:_**
![image](https://github.com/PolkaGate/polkagate-extension/assets/75857984/1e25a8dc-6af9-4905-a76f-11bb561c139e)
