### PR TITLE
Add ledger sign for ledger tagged accounts

### DIFF
--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -43,10 +43,10 @@ export interface AccountJson extends KeyringPair$Meta {
   whenCreated?: number;
 
   // added for polkagate
-  txHistory?: string;
-  nominatedValidators?: string;
-  poolNominatedValidators?: string;
-  endpoint?: string;
+  // txHistory?: string;
+  // nominatedValidators?: string; // can be removed
+  // poolNominatedValidators?: string; // can be removed
+  // endpoint?: string; // can be removed
   balances?: string;
   stakingAccount?: string;
   identities?: string;

--- a/packages/extension-polkagate/src/components/SignArea2.tsx
+++ b/packages/extension-polkagate/src/components/SignArea2.tsx
@@ -12,10 +12,9 @@ import { Grid, Tooltip, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { SubmittableExtrinsicFunction } from '@polkadot/api/types/submittable';
-import { Chain } from '@polkadot/extension-chains/types';
 import keyring from '@polkadot/ui-keyring';
 
-import { useAccount, useAccountDisplay, useApi, useFormatted, useProxies, useTranslation } from '../hooks';
+import { useAccount, useAccountDisplay, useApi, useChain, useFormatted, useProxies, useTranslation } from '../hooks';
 import { DraggableModal } from '../popup/governance/components/DraggableModal';
 import SelectProxyModal2 from '../popup/governance/components/SelectProxyModal2';
 import LedgerSign from '../popup/signing/LedgerSign';
@@ -26,11 +25,9 @@ import { Identity, Password, PButton, TwoButtons, Warning } from '.';
 
 interface Props {
   address: string;
-  chain: Chain | null | undefined;
   call: SubmittableExtrinsicFunction<'promise', AnyTuple> | undefined
   disabled?: boolean;
   isPasswordError?: boolean;
-  onChange: React.Dispatch<React.SetStateAction<string | undefined>>
   onSecondaryClick: () => void;
   params: unknown[] | (() => unknown[]) | undefined;
   primaryBtn?: boolean;
@@ -46,14 +43,15 @@ interface Props {
   showBackButtonWithUseProxy?: boolean;
   to?: string;
   setTxInfo: React.Dispatch<React.SetStateAction<TxInfo | undefined>>;
-  extraInfo: Record<string, string | number | undefined>;
+  extraInfo: Record<string, unknown>;
   steps: Record<string, number>;
 }
 
 /** This puts usually at the end of review page where user can do enter password, choose proxy or use other alternatives like signing using ledger */
-export default function SignAre({ address, call, chain, disabled, extraInfo, isPasswordError, onChange, onSecondaryClick, params, prevState, primaryBtn, primaryBtnText, secondaryBtnText, selectedProxy, setIsPasswordError, setSelectedProxy, setStep, setTxInfo, showBackButtonWithUseProxy = true, steps, to }: Props): React.ReactElement<Props> {
+export default function SignAre({ address, call, disabled, extraInfo, isPasswordError, onSecondaryClick, params, prevState, primaryBtn, primaryBtnText, secondaryBtnText, selectedProxy, setIsPasswordError, setSelectedProxy, setStep, setTxInfo, showBackButtonWithUseProxy = true, steps, to }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const theme = useTheme();
+  const chain = useChain(address);
   const senderName = useAccountDisplay(address);
   const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxy?.delegate));
 
@@ -144,10 +142,6 @@ export default function SignAre({ address, call, chain, disabled, extraInfo, isP
   const closeSelectProxy = useCallback(() => {
     setShowProxy(false);
   }, []);
-
-  useEffect(() => {
-    onChange(password);
-  }, [password, onChange]);
 
   const handleTxResult = useCallback((txResult) => {
     try {

--- a/packages/extension-polkagate/src/components/SignArea2.tsx
+++ b/packages/extension-polkagate/src/components/SignArea2.tsx
@@ -51,7 +51,7 @@ interface Props {
 }
 
 /** This puts usually at the end of review page where user can do enter password, choose proxy or use other alternatives like signing using ledger */
-export default function SignAre({ address, call, steps, chain, disabled, extraInfo, isPasswordError, onChange, onSecondaryClick, params, prevState, primaryBtn, primaryBtnText, secondaryBtnText, selectedProxy, setIsPasswordError, setSelectedProxy, setStep, setTxInfo, showBackButtonWithUseProxy = true, to }: Props): React.ReactElement<Props> {
+export default function SignAre({ address, call, chain, disabled, extraInfo, isPasswordError, onChange, onSecondaryClick, params, prevState, primaryBtn, primaryBtnText, secondaryBtnText, selectedProxy, setIsPasswordError, setSelectedProxy, setStep, setTxInfo, showBackButtonWithUseProxy = true, steps, to }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const theme = useTheme();
   const senderName = useAccountDisplay(address);
@@ -62,7 +62,6 @@ export default function SignAre({ address, call, steps, chain, disabled, extraIn
   const api = useApi(address);
   const proxies = useProxies(api, formatted);
 
-  console.log('account:',account)
   const [proxyItems, setProxyItems] = useState<ProxyItem[]>();
   const [password, setPassword] = useState<string>();
   const mustSelectProxy = useMemo(() => !account?.isHardware && account?.isExternal && !selectedProxy, [account, selectedProxy]);
@@ -217,26 +216,37 @@ export default function SignAre({ address, call, steps, chain, disabled, extraIn
     <Grid container>
       {isLedger
         ? <>
-          {!error &&
-            <Grid alignItems='center' container height='50px' item justifyContent='center' sx={{ '> div': { m: 0, p: 0 }, pt: '5px' }}>
-              <Warning
-                fontWeight={300}
-                theme={theme}
-              >
-                {t('This is a ledger account. To complete this transaction, use your ledger.')}
-              </Warning>
+
+          <Grid alignItems='center' container height='50px' item justifyContent='center' sx={{ '> div': { m: 0, p: 0 }, pt: '5px' }}>
+            <Warning
+              fontWeight={300}
+              isDanger={!!error}
+              theme={theme}
+            >
+              {error || t('This is a ledger account. To complete this transaction, use your ledger.')}
+            </Warning>
+          </Grid>
+          <Grid container item justifyContent='space-between'>
+            <Grid item sx={{ mt: '18px' }} xs={3}>
+              <PButton
+                _mt='1px'
+                _onClick={() => setStep(0)}
+                _variant='outlined'
+                text={t('Cancel')}
+              />
             </Grid>
-          }
-          <Grid container item justifyContent='center' sx={{ position: 'relative', mt: '50px', '> div': { justifyContent: 'center' }, ' button': { m: 0 } }}>
-            <LedgerSign
-              accountIndex={account?.accountIndex as number || 0}
-              addressOffset={account?.addressOffset as number || 0}
-              error={error}
-              genesisHash={account?.genesisHash || api?.genesisHash?.toHex()}
-              onSignature={onSignature}
-              payload={payload}
-              setError={setError}
-            />
+            <Grid item xs={8} sx={{ ' button': { m: 0, width: '100%' }, mt: '80px', position: 'relative', width: '70%' }}>
+              <LedgerSign
+                accountIndex={account?.accountIndex as number || 0}
+                addressOffset={account?.addressOffset as number || 0}
+                error={error}
+                genesisHash={account?.genesisHash || api?.genesisHash?.toHex()}
+                onSignature={onSignature}
+                payload={payload}
+                setError={setError}
+                showError={false}
+              />
+            </Grid>
           </Grid>
         </>
         : <>
@@ -344,7 +354,8 @@ export default function SignAre({ address, call, steps, chain, disabled, extraIn
           }
         </>
       }
-      {showProxy &&
+      {
+        showProxy &&
         <DraggableModal onClose={closeSelectProxy} open={showProxy}>
           <Grid container item>
             <Grid alignItems='center' container item justifyContent='space-between'>
@@ -358,16 +369,15 @@ export default function SignAre({ address, call, steps, chain, disabled, extraIn
             <SelectProxyModal2
               address={address}
               closeSelectProxy={closeSelectProxy}
+              height={500}
+              proxies={proxyItems}
               proxyTypeFilter={['Any']}
               selectedProxy={selectedProxy}
               setSelectedProxy={setSelectedProxy}
-              height={500}
-              // nextStep={STEPS.REVIEW}
-              proxies={proxyItems}
             />
           </Grid>
         </DraggableModal>
       }
-    </Grid>
+    </Grid >
   );
 }

--- a/packages/extension-polkagate/src/components/SignArea2.tsx
+++ b/packages/extension-polkagate/src/components/SignArea2.tsx
@@ -1,0 +1,373 @@
+// Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import type { Header } from '@polkadot/types/interfaces';
+import type { AnyTuple } from '@polkadot/types/types';
+import type { HexString } from '@polkadot/util/types';
+
+import { Close as CloseIcon } from '@mui/icons-material';
+import { Grid, Tooltip, Typography, useTheme } from '@mui/material';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { SubmittableExtrinsicFunction } from '@polkadot/api/types/submittable';
+import { Chain } from '@polkadot/extension-chains/types';
+import keyring from '@polkadot/ui-keyring';
+
+import { useAccount, useAccountDisplay, useApi, useFormatted, useProxies, useTranslation } from '../hooks';
+import { DraggableModal } from '../popup/governance/components/DraggableModal';
+import SelectProxyModal2 from '../popup/governance/components/SelectProxyModal2';
+import LedgerSign from '../popup/signing/LedgerSign';
+import { send, signAndSend } from '../util/api';
+import { Proxy, ProxyItem, ProxyTypes, TxInfo } from '../util/types';
+import { getSubstrateAddress, saveAsHistory } from '../util/utils';
+import { Identity, Password, PButton, TwoButtons, Warning } from '.';
+
+interface Props {
+  address: string;
+  chain: Chain | null | undefined;
+  call: SubmittableExtrinsicFunction<'promise', AnyTuple> | undefined
+  disabled?: boolean;
+  isPasswordError?: boolean;
+  onChange: React.Dispatch<React.SetStateAction<string | undefined>>
+  onSecondaryClick: () => void;
+  params: unknown[] | (() => unknown[]) | undefined;
+  primaryBtn?: boolean;
+  primaryBtnText?: string
+  prevState?: Record<string, any>;
+  proxyTypeFilter: ProxyTypes[] | string[];
+  secondaryBtnText?: string
+  selectedProxy: Proxy | undefined;
+  setSelectedProxy: React.Dispatch<React.SetStateAction<Proxy | undefined>>;
+  setIsPasswordError: React.Dispatch<React.SetStateAction<boolean>>;
+  step: number;
+  setStep: React.Dispatch<React.SetStateAction<number>>;
+  showBackButtonWithUseProxy?: boolean;
+  to?: string;
+  setTxInfo: React.Dispatch<React.SetStateAction<TxInfo | undefined>>;
+  extraInfo: Record<string, string | number | undefined>;
+  steps: Record<string, number>;
+}
+
+/** This puts usually at the end of review page where user can do enter password, choose proxy or use other alternatives like signing using ledger */
+export default function SignAre({ address, call, steps, chain, disabled, extraInfo, isPasswordError, onChange, onSecondaryClick, params, prevState, primaryBtn, primaryBtnText, secondaryBtnText, selectedProxy, setIsPasswordError, setSelectedProxy, setStep, setTxInfo, showBackButtonWithUseProxy = true, to }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const senderName = useAccountDisplay(address);
+  const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxy?.delegate));
+
+  const account = useAccount(address);
+  const formatted = useFormatted(address);
+  const api = useApi(address);
+  const proxies = useProxies(api, formatted);
+
+  console.log('account:',account)
+  const [proxyItems, setProxyItems] = useState<ProxyItem[]>();
+  const [password, setPassword] = useState<string>();
+  const mustSelectProxy = useMemo(() => !account?.isHardware && account?.isExternal && !selectedProxy, [account, selectedProxy]);
+  const [error, setError] = useState<string | null>();
+  const [showProxy, setShowProxy] = useState<boolean>();
+  const [lastHeader, setLastHeader] = useState<Header>();
+  const [rawNonce, setRawNonce] = useState<number>();
+
+  const from = selectedProxy?.delegate ?? formatted;
+
+  const ptx = useMemo(() => {
+    if (!call || !params || !api) {
+      return;
+    }
+
+    const tx = call(...params);
+
+    return selectedProxy ? api.tx.proxy.proxy(formatted, selectedProxy.proxyType, tx) : tx;
+  }, [api, call, formatted, params, selectedProxy]);
+
+  const payload = useMemo(() => {
+    if (!api || !ptx || !lastHeader || !rawNonce) {
+      return;
+    }
+
+    const _payload = {
+      address: from,
+      blockHash: lastHeader.hash.toHex(),
+      blockNumber: api.registry.createType('BlockNumber', lastHeader.number.toNumber()).toHex(),
+      era: api.registry.createType('ExtrinsicEra', { current: lastHeader.number.toNumber(), period: 64 }).toHex(),
+      genesisHash: api.genesisHash.toHex(),
+      method: api.createType('Call', ptx).toHex(), // TODO: DOES SUPPORT nested calls, batches , ...
+      nonce: api.registry.createType('Compact<Index>', rawNonce).toHex(),
+      signedExtensions: [
+        'CheckNonZeroSender',
+        'CheckSpecVersion',
+        'CheckTxVersion',
+        'CheckGenesis',
+        'CheckMortality',
+        'CheckNonce',
+        'CheckWeight',
+        'ChargeTransactionPayment'
+      ],
+      specVersion: api.runtimeVersion.specVersion.toHex(),
+      tip: api.registry.createType('Compact<Balance>', 0).toHex(),
+      transactionVersion: api.runtimeVersion.transactionVersion.toHex(),
+      version: ptx.version
+    };
+
+    return api.registry.createType('ExtrinsicPayload', _payload, { version: _payload.version });
+  }, [api, from, lastHeader, rawNonce, ptx]);
+
+  const isLedger = useMemo(() => account?.isHardware, [account?.isHardware]);
+  const selectedProxyAddress = selectedProxy?.delegate as unknown as string;
+
+  useEffect((): void => {
+    if (api && from) {
+      api.rpc.chain.getHeader().then(setLastHeader).catch(console.error);
+      api.query.system.account(from).then((res) => setRawNonce(res?.nonce || 0)).catch(console.error);
+    }
+  }, [api, formatted, from, selectedProxy]);
+
+  useEffect((): void => {
+    const fetchedProxyItems = proxies?.map((p: Proxy) => ({ proxy: p, status: 'current' })) as ProxyItem[];
+
+    setProxyItems(fetchedProxyItems);
+  }, [proxies]);
+
+  const _onChange = useCallback(
+    (pass: string): void => {
+      pass.length > 3 && pass && setPassword(pass);
+      pass.length > 3 && pass && setIsPasswordError && setIsPasswordError(false);
+    }, [setIsPasswordError]
+  );
+
+  const goToSelectProxy = useCallback(() => {
+    setShowProxy(true);
+  }, []);
+
+  const closeSelectProxy = useCallback(() => {
+    setShowProxy(false);
+  }, []);
+
+  useEffect(() => {
+    onChange(password);
+  }, [password, onChange]);
+
+  const handleTxResult = useCallback((txResult) => {
+    try {
+      if (!txResult || !api || !chain) {
+        return;
+      }
+
+      const token = api.registry.chainTokens[0];
+      const decimal = api.registry.chainDecimals[0];
+
+      const info = {
+        block: txResult?.block || 0,
+        chain,
+        date: Date.now(),
+        decimal,
+        failureText: txResult?.failureText,
+        from: { address: String(formatted), name: senderName },
+        success: txResult?.success,
+        throughProxy: selectedProxyAddress ? { address: selectedProxyAddress, name: selectedProxyName } : undefined,
+        token,
+        txHash: txResult?.txHash || '',
+        ...extraInfo
+      };
+
+      setTxInfo({ ...info, api, chain });
+      saveAsHistory(String(from), info);
+      setStep(steps.CONFIRM);
+    } catch (e) {
+      console.log('error:', e);
+    }
+  }, [api, chain, extraInfo, formatted, from, selectedProxyAddress, selectedProxyName, senderName, setStep, setTxInfo, steps]);
+
+  const onConfirm = useCallback(async () => {
+    try {
+      if (!formatted || !api || !ptx || !from) {
+        return;
+      }
+
+      const signer = keyring.getPair(from);
+
+      signer.unlock(password);
+      setStep(steps.WAIT_SCREEN);
+
+      const txResult = await signAndSend(api, ptx, signer, formatted);
+
+      handleTxResult(txResult);
+    } catch (e) {
+      console.log('error:', e);
+      setIsPasswordError(true);
+    }
+  }, [api, formatted, from, handleTxResult, password, ptx, setIsPasswordError, setStep, steps]);
+
+  const onSignature = useCallback(async ({ signature }: { signature: HexString }) => {
+    if (!api || !payload || !signature || !ptx || !from) {
+      return;
+    }
+
+    setStep(steps.WAIT_SCREEN);
+
+    const txResult = await send(from, api, ptx, payload, signature);
+
+    handleTxResult(txResult);
+  }, [api, from, handleTxResult, payload, ptx, setStep, steps.WAIT_SCREEN]);
+
+  return (
+    <Grid container>
+      {isLedger
+        ? <>
+          {!error &&
+            <Grid alignItems='center' container height='50px' item justifyContent='center' sx={{ '> div': { m: 0, p: 0 }, pt: '5px' }}>
+              <Warning
+                fontWeight={300}
+                theme={theme}
+              >
+                {t('This is a ledger account. To complete this transaction, use your ledger.')}
+              </Warning>
+            </Grid>
+          }
+          <Grid container item justifyContent='center' sx={{ position: 'relative', mt: '50px', '> div': { justifyContent: 'center' }, ' button': { m: 0 } }}>
+            <LedgerSign
+              accountIndex={account?.accountIndex as number || 0}
+              addressOffset={account?.addressOffset as number || 0}
+              error={error}
+              genesisHash={account?.genesisHash || api?.genesisHash?.toHex()}
+              onSignature={onSignature}
+              payload={payload}
+              setError={setError}
+            />
+          </Grid>
+        </>
+        : <>
+          {mustSelectProxy
+            ? <>
+              <Grid container height='50px' item sx={{ '> div': { m: 0, p: 0 }, pt: '5px' }}>
+                <Warning
+                  fontWeight={300}
+                  theme={theme}
+                >
+                  {t('This is a watch-only account. To complete this transaction, you must use a proxy.')}
+                </Warning>
+              </Grid>
+              {showBackButtonWithUseProxy
+                ? <TwoButtons
+                  mt='5px'
+                  onPrimaryClick={goToSelectProxy}
+                  onSecondaryClick={onSecondaryClick}
+                  primaryBtnText={t<string>('Use Proxy')}
+                  secondaryBtnText={t<string>('Back')}
+                />
+                : <PButton
+                  _ml={0}
+                  _mt='5px'
+                  _onClick={goToSelectProxy}
+                  _width={100}
+                  text={t<string>('Use Proxy')}
+                />
+              }
+            </>
+            : <>
+              <Grid alignItems='center' container item>
+                <Grid item xs>
+                  <Password
+                    disabled={disabled}
+                    isError={isPasswordError}
+                    isFocused={true}
+                    label={`${t<string>('Password')} for ${selectedProxyName || senderName || ''}`}
+                    onChange={_onChange}
+                    onEnter={onConfirm}
+                  />
+                </Grid>
+                {(!!proxies?.length || prevState?.selectedProxyAddress) &&
+                  <Tooltip
+                    arrow
+                    componentsProps={{
+                      popper: {
+                        sx: {
+                          '.MuiTooltip-tooltip.MuiTooltip-tooltipPlacementTop.css-18kejt8': {
+                            mb: '3px',
+                            p: '3px 15px'
+                          },
+                          '.MuiTooltip-tooltip.MuiTooltip-tooltipPlacementTop.css-1yuxi3g': {
+                            mb: '3px',
+                            p: '3px 15px'
+                          },
+                          visibility: selectedProxy ? 'visible' : 'hidden'
+                        }
+                      },
+                      tooltip: {
+                        sx: {
+                          '& .MuiTooltip-arrow': {
+                            color: '#fff',
+                            height: '10px'
+                          },
+                          backgroundColor: '#fff',
+                          color: '#000',
+                          fontWeight: 400
+                        }
+                      }
+                    }}
+                    leaveDelay={300}
+                    placement='top-start'
+                    sx={{ width: 'fit-content' }}
+                    title={
+                      <>
+                        {selectedProxy &&
+                          <Identity
+                            chain={chain}
+                            formatted={selectedProxy?.delegate}
+                            identiconSize={30}
+                            style={{ fontSize: '14px' }}
+                          />
+                        }
+                      </>
+                    }
+                  >
+                    <Grid aria-label='useProxy' item onClick={goToSelectProxy} pl='10px' pt='10px' role='button' sx={{ cursor: 'pointer', fontWeight: 400, textDecorationLine: 'underline' }}              >
+                      {selectedProxy ? t('Update proxy') : t('Use proxy')}
+                    </Grid>
+                  </Tooltip>
+                }
+              </Grid>
+              <Grid alignItems='center' container id='TwoButtons' item sx={{ '> div': { m: 0, width: '100%' }, pt: '15px' }}>
+                <TwoButtons
+                  disabled={!password || isPasswordError || primaryBtn || disabled}
+                  mt='8px'
+                  onPrimaryClick={onConfirm}
+                  onSecondaryClick={onSecondaryClick}
+                  primaryBtnText={primaryBtnText ?? t<string>('Confirm')}
+                  secondaryBtnText={secondaryBtnText ?? t<string>('Back')}
+                />
+              </Grid>
+            </>
+          }
+        </>
+      }
+      {showProxy &&
+        <DraggableModal onClose={closeSelectProxy} open={showProxy}>
+          <Grid container item>
+            <Grid alignItems='center' container item justifyContent='space-between'>
+              <Typography fontSize='22px' fontWeight={700}>
+                {t<string>('Select Proxy')}
+              </Typography>
+              <Grid item>
+                <CloseIcon onClick={closeSelectProxy} sx={{ color: 'primary.main', cursor: 'pointer', stroke: theme.palette.primary.main, strokeWidth: 1.5 }} />
+              </Grid>
+            </Grid>
+            <SelectProxyModal2
+              address={address}
+              closeSelectProxy={closeSelectProxy}
+              proxyTypeFilter={['Any']}
+              selectedProxy={selectedProxy}
+              setSelectedProxy={setSelectedProxy}
+              height={500}
+              // nextStep={STEPS.REVIEW}
+              proxies={proxyItems}
+            />
+          </Grid>
+        </DraggableModal>
+      }
+    </Grid>
+  );
+}

--- a/packages/extension-polkagate/src/components/index.ts
+++ b/packages/extension-polkagate/src/components/index.ts
@@ -74,5 +74,6 @@ export { default as TwoButtons } from './TwoButtons';
 export { default as ValidatedInput } from './ValidatedInput';
 export { default as WrongPasswordAlert } from './WrongPasswordAlert';
 export { default as Warning } from './Warning';
+export { default as SignArea2 } from './SignArea2';
 
 export * from './contexts';

--- a/packages/extension-polkagate/src/popup/governance/components/SelectProxyModal2.tsx
+++ b/packages/extension-polkagate/src/popup/governance/components/SelectProxyModal2.tsx
@@ -1,0 +1,94 @@
+// Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import { Grid, Typography } from '@mui/material';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { AccountsStore } from '@polkadot/extension-base/stores';
+import keyring from '@polkadot/ui-keyring';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+
+import { PButton, ProxyTable } from '../../../components';
+import { useChain, useTranslation } from '../../../hooks';
+import { Proxy, ProxyItem } from '../../../util/types';
+
+interface Props {
+  address: string | undefined;
+  selectedProxy: Proxy | undefined
+  setSelectedProxy: React.Dispatch<React.SetStateAction<Proxy | undefined>>
+  proxyTypeFilter: string[]
+  proxies: ProxyItem[] | undefined;
+  // setStep: React.Dispatch<React.SetStateAction<number>>;
+  height: number | undefined;
+  // nextStep: number;
+   closeSelectProxy: () => void
+
+}
+
+export default function SelectProxyModal({ address, height,closeSelectProxy, proxies, proxyTypeFilter, selectedProxy, setSelectedProxy }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+  const chain = useChain(address);
+  const [proxiesToSelect, setProxiesToSelect] = useState<ProxyItem[] | undefined>();
+  const [change, setChange] = useState<boolean>(true);
+
+  useEffect(() => {
+    const toSelect = proxies?.filter((item) => item.status !== 'new');
+
+    setProxiesToSelect(toSelect);
+  }, [proxies]);
+
+  useEffect(() => {
+    cryptoWaitReady().then(() => keyring.loadAll({ store: new AccountsStore() })).catch(() => null);
+  }, []);
+
+  const handleNext = useCallback(() => {
+    setChange(true);
+    // setStep(nextStep);
+    closeSelectProxy();
+  }, [closeSelectProxy]);
+
+  const onSelect = useCallback((selected: Proxy) => {
+    setChange(!change);
+    setSelectedProxy(selected);
+  }, [change, setSelectedProxy]);
+
+  const onDeselect = useCallback(() => {
+    selectedProxy && setChange(!change);
+    selectedProxy && setSelectedProxy(undefined);
+  }, [change, selectedProxy, setSelectedProxy]);
+
+  return (
+    <Grid container direction='column' height={`${height ?? 300}px`}>
+      <Typography fontSize='14px' fontWeight={300} m='18px auto 0' pt='25px' textAlign='left'>
+        {t('Choose a suitable proxy for the account to conduct the transaction on its behalf.')}
+      </Typography>
+      <ProxyTable
+        chain={chain}
+        label={t<string>('Proxies')}
+        maxHeight='300px'
+        mode='Select'
+        onSelect={onSelect}
+        proxies={proxiesToSelect}
+        proxyTypeFilter={proxyTypeFilter}
+        selected={selectedProxy}
+        style={{
+          m: '20px auto 0',
+          width: '100%'
+        }}
+      />
+      <Grid container item justifyContent='flex-end' onClick={onDeselect}>
+        <Typography fontSize='14px' fontWeight={400} lineHeight='36px' sx={{ cursor: selectedProxy ? 'pointer' : 'default', textAlign: 'right', textDecoration: 'underline' }}>
+          {t<string>('Clear selection and use the proxied')}
+        </Typography>
+      </Grid>
+      <PButton
+        _ml={0}
+        _onClick={handleNext}
+        disabled={change}
+        text={t('Apply')}
+      />
+    </Grid>
+  );
+}

--- a/packages/extension-polkagate/src/popup/governance/components/SelectProxyModal2.tsx
+++ b/packages/extension-polkagate/src/popup/governance/components/SelectProxyModal2.tsx
@@ -4,7 +4,7 @@
 /* eslint-disable react/jsx-max-props-per-line */
 
 import { Grid, Typography } from '@mui/material';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useMemo } from 'react';
 
 import { AccountsStore } from '@polkadot/extension-base/stores';
 import keyring from '@polkadot/ui-keyring';
@@ -20,24 +20,16 @@ interface Props {
   setSelectedProxy: React.Dispatch<React.SetStateAction<Proxy | undefined>>
   proxyTypeFilter: string[]
   proxies: ProxyItem[] | undefined;
-  // setStep: React.Dispatch<React.SetStateAction<number>>;
   height: number | undefined;
-  // nextStep: number;
-   closeSelectProxy: () => void
-
+  closeSelectProxy: () => void
 }
 
-export default function SelectProxyModal({ address, height,closeSelectProxy, proxies, proxyTypeFilter, selectedProxy, setSelectedProxy }: Props): React.ReactElement<Props> {
+export default function SelectProxyModal({ address, closeSelectProxy, height, proxies, proxyTypeFilter, selectedProxy, setSelectedProxy }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const chain = useChain(address);
-  const [proxiesToSelect, setProxiesToSelect] = useState<ProxyItem[] | undefined>();
   const [change, setChange] = useState<boolean>(true);
 
-  useEffect(() => {
-    const toSelect = proxies?.filter((item) => item.status !== 'new');
-
-    setProxiesToSelect(toSelect);
-  }, [proxies]);
+  const proxiesToSelect = useMemo(() => proxies?.filter((item) => item.status !== 'new'), [proxies]);
 
   useEffect(() => {
     cryptoWaitReady().then(() => keyring.loadAll({ store: new AccountsStore() })).catch(() => null);
@@ -45,7 +37,6 @@ export default function SelectProxyModal({ address, height,closeSelectProxy, pro
 
   const handleNext = useCallback(() => {
     setChange(true);
-    // setStep(nextStep);
     closeSelectProxy();
   }, [closeSelectProxy]);
 

--- a/packages/extension-polkagate/src/popup/governance/delegate/DelegationDetails.tsx
+++ b/packages/extension-polkagate/src/popup/governance/delegate/DelegationDetails.tsx
@@ -285,7 +285,6 @@ export default function DelegationDetails({ accountLocks, address, balances, fil
           setDelegateInformation={setDelegateInformation}
           setModalHeight={setModalHeight}
           setMode={setMode}
-          setSelectedTracksLength={setSelectedTracksLength}
           setStep={setStep}
           setTxInfo={setTxInfo}
           step={step}

--- a/packages/extension-polkagate/src/popup/governance/delegate/partial/Confirmation.tsx
+++ b/packages/extension-polkagate/src/popup/governance/delegate/partial/Confirmation.tsx
@@ -9,9 +9,9 @@ import React from 'react';
 import { Motion, PButton, ShortAddress } from '../../../../components';
 import { useToken, useTranslation } from '../../../../hooks';
 import { ThroughProxy } from '../../../../partials';
+import { TxInfo } from '../../../../util/types';
 import Explorer from '../../../history/Explorer';
 import FailSuccessIcon from '../../../history/partials/FailSuccessIcon';
-import { TxInfo } from '../../../../util/types';
 import { DelegateInformation } from '..';
 
 interface Props {

--- a/packages/extension-polkagate/src/popup/governance/delegate/partial/ReferendaTracks.tsx
+++ b/packages/extension-polkagate/src/popup/governance/delegate/partial/ReferendaTracks.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react/jsx-max-props-per-line */
 
 import { Grid, List, ListItem, ListItemButton, ListItemIcon, ListItemText, Skeleton, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { BN } from '@polkadot/util';
 

--- a/packages/extension-polkagate/src/popup/signing/LedgerSign.tsx
+++ b/packages/extension-polkagate/src/popup/signing/LedgerSign.tsx
@@ -1,6 +1,8 @@
 // Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+/* eslint-disable react/jsx-max-props-per-line */
+
 import type { ExtrinsicPayload } from '@polkadot/types/interfaces';
 import type { HexString } from '@polkadot/util/types';
 
@@ -21,9 +23,10 @@ interface Props {
   onSignature?: ({ signature }: { signature: HexString }) => void;
   payload?: ExtrinsicPayload;
   setError: (value: string | null) => void;
+  showError?: boolean;
 }
 
-function LedgerSign({ accountIndex, addressOffset, error, genesisHash, onSignature, payload, setError }: Props): React.ReactElement<Props> {
+function LedgerSign({ accountIndex, addressOffset, error, genesisHash, onSignature, payload, setError, showError = true }: Props): React.ReactElement<Props> {
   const [isBusy, setIsBusy] = useState(false);
   const { t } = useTranslation();
   const theme = useTheme();
@@ -61,31 +64,27 @@ function LedgerSign({ accountIndex, addressOffset, error, genesisHash, onSignatu
 
   return (
     <Grid container>
-      {!!ledgerWarning && (
+      {!!ledgerWarning &&
         <Warning marginTop={0} theme={theme}>
           {ledgerWarning}
         </Warning>
-      )}
-      {error && (
-        <Warning marginTop={0} isDanger theme={theme}>
+      }
+      {error && showError &&
+        <Warning isDanger marginTop={0} theme={theme}>
           {error}
         </Warning>
-      )}
-      {(ledgerLocked || error)
-        ? (
-          <PButton
-            _isBusy={isBusy || ledgerLoading}
-            _onClick={_onRefresh}
-            text={t<string>('Refresh')}
-          />
-        )
-        : (
-          <PButton
-            _isBusy={isBusy || ledgerLoading}
-            _onClick={_onSignLedger}
-            text={t<string>('Sign on Ledger')}
-          />
-        )
+      }
+      {ledgerLocked || error
+        ? <PButton
+          _isBusy={isBusy || ledgerLoading}
+          _onClick={_onRefresh}
+          text={t<string>('Refresh')}
+        />
+        : <PButton
+          _isBusy={isBusy || ledgerLoading}
+          _onClick={_onSignLedger}
+          text={t<string>('Sign on Ledger')}
+        />
       }
     </Grid>
   );

--- a/packages/extension-polkagate/src/util/api/signAndSend.ts
+++ b/packages/extension-polkagate/src/util/api/signAndSend.ts
@@ -1,7 +1,9 @@
 // Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AccountId } from '@polkadot/types/interfaces';
+import type { AccountId, ExtrinsicPayload } from '@polkadot/types/interfaces';
+import type { AnyTuple } from '@polkadot/types/types';
+import type { HexString } from '@polkadot/util/types';
 
 import { ApiPromise } from '@polkadot/api';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
@@ -67,6 +69,57 @@ export async function signAndSend(
         //     }
         //   }
         // });
+      }
+    }).catch((e) => {
+      console.log('catch error', e);
+      resolve({ block: 0, failureText: String(e), fee: '', success: false, txHash: '' });
+    });
+  });
+}
+
+export async function send(from: string | AccountId, api: ApiPromise, ptx: SubmittableExtrinsic<'promise', ISubmittableResult>, payload: ExtrinsicPayload, signature: HexString): Promise<TxResult> {
+  return new Promise((resolve) => {
+    console.log('sending a tx ...');
+
+    ptx.addSignature(from, signature, payload);
+
+    // eslint-disable-next-line no-void
+    void ptx.send(async (result) => {
+      let success = true;
+      let failureText = '';
+      const parsedRes = JSON.parse(JSON.stringify(result));
+      const event = new CustomEvent('transactionState', { detail: parsedRes.status });
+
+      window.dispatchEvent(event);
+      console.log(parsedRes);
+
+      if (result.dispatchError) {
+        if (result.dispatchError.isModule) {
+          // for module errors, we have the section indexed, lookup
+          const decoded = api.registry.findMetaError(result.dispatchError.asModule);
+          const { docs, name, section } = decoded;
+
+          success = false;
+          failureText = `${docs.join(' ')}`;
+
+          console.log(`dispatchError module: ${section}.${name}: ${docs.join(' ')}`);
+        } else {
+          // Other, CannotLookup, BadOrigin, no extra info
+          console.log(`dispatchError other reason: ${result.dispatchError.toString()}`);
+        }
+      }
+
+      if (result.status.isFinalized || result.status.isInBlock) {
+        console.log('Tx. Status: ', result.status);
+        const hash = result.status.isFinalized ? result.status.asFinalized : result.status.asInBlock;
+
+        const signedBlock = await api.rpc.chain.getBlock(hash);
+        const blockNumber = signedBlock.block.header.number;
+        const txHash = result.txHash.toString();
+
+        const fee = undefined;
+
+        resolve({ block: Number(blockNumber), failureText, fee, success, txHash });
       }
     }).catch((e) => {
       console.log('catch error', e);


### PR DESCRIPTION
- updated full screen review pages including "Send fund" and "Governance" pages
- in the next step can be added to popUp reviews as well


closes #590
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Features:**
- Added support for using a proxy for watch-only accounts in the `SignArea` component.
- Introduced a new `SelectProxyModal` component for selecting a suitable proxy for an account.
- Enhanced transaction signing with Ledger devices and improved error handling.

**Refactor:**
- Replaced `PasswordWithTwoButtonsAndUseProxy` component with the more functional `SignArea2` across multiple components.
- Optimized state management and side-effect handling in several components, including `Review`, `ModifyDelegate`, and `RemoveDelegate`.

**Chore:**
- Cleaned up unused imports, variables, and commented-out code across various files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->