### PR TITLE
Full screen create account

### DIFF
--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -3,7 +3,7 @@
 
 const ALLOWED_PATH = ['/', '/account/import-ledger', '/account/restore-json'] as const;
 // Added for Polkagate
-const START_WITH_PATH = ['/governance/', '/manageIdentity/', '/send/', '/socialRecovery/'] as const;
+const START_WITH_PATH = ['/governance/', '/manageIdentity/', '/send/', '/account/', '/socialRecovery/'] as const;
 const PHISHING_PAGE_REDIRECT = '/phishing-page-detected';
 // const EXTENSION_PREFIX = process.env.EXTENSION_PREFIX as string || '';
 const EXTENSION_PREFIX = 'POLKAGATE';

--- a/packages/extension-polkagate/src/components/MnemonicSeed.tsx
+++ b/packages/extension-polkagate/src/components/MnemonicSeed.tsx
@@ -24,7 +24,7 @@ export default function MnemonicSeed({ isCopied, onCopy, seed, setIsCopied }: Pr
       <TextAreaWithLabel
         className='mnemonicDisplay'
         isReadOnly
-        label={t<string>('Generated 12-word mnemonic seed:')}
+        label={t<string>('Generated 12-word recovery phrase:')}
         style={{ margin: 'auto', width: '92%' }}
         value={seed}
       />

--- a/packages/extension-polkagate/src/components/index.ts
+++ b/packages/extension-polkagate/src/components/index.ts
@@ -79,6 +79,7 @@ export { default as RescueRecoveryIcon } from './SVG/RescueRecoveryIcon';
 export { default as VouchRecoveryIcon } from './SVG/VouchRecoveryIcon';
 export { default as SocialRecoveryIcon } from './SVG/SocialRecoveryIcon';
 export { default as SignArea2 } from './SignArea2';
+export { default as Affirm } from './Affirm';
 export { default as CanPayErrorAlert } from './CanPayErrorAlert';
 
 export * from './contexts';

--- a/packages/extension-polkagate/src/partials/ImportAccSubMenu.tsx
+++ b/packages/extension-polkagate/src/partials/ImportAccSubMenu.tsx
@@ -90,7 +90,7 @@ function ImportAccSubMenu({ show, toggleSettingSubMenu }: Props): React.ReactEle
           }
           onClick={_goToImportAcc}
           py='4px'
-          text={t('Import from mnemonic')}
+          text={t('Import from recovery phrase')}
         />
         <MenuItem
           iconComponent={

--- a/packages/extension-polkagate/src/partials/NewAccountSubMenu.tsx
+++ b/packages/extension-polkagate/src/partials/NewAccountSubMenu.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { AccountContext, ActionContext, MenuItem } from '../components';
 import { useTranslation } from '../hooks';
+import { windowOpen } from '../messaging';
 
 interface Props {
   show: boolean;
@@ -35,8 +36,8 @@ function NewAccountSubMenu({ show }: Props): React.ReactElement<Props> {
 
   const _goToCreateAcc = useCallback(
     () => {
-      onAction('/account/create');
-    }, [onAction]
+      windowOpen('/account/create').catch(console.error);
+    }, []
   );
 
   const slideIn = keyframes`

--- a/packages/extension-polkagate/src/popup/createAccount/Mnemonic.tsx
+++ b/packages/extension-polkagate/src/popup/createAccount/Mnemonic.tsx
@@ -43,13 +43,13 @@ function Mnemonic({ onNextStep, seed }: Props): React.ReactElement<Props> {
         setIsCopied={setIsCopied}
       />
       <Warning iconDanger marginTop={43} theme={theme}>
-        {t<string>('Please write down your wallet’s mnemonic seed and keep it in a safe place. The mnemonic can be used to restore your wallet. Keep it carefully to not lose your assets.')}
+        {t<string>('Please write down your wallet’s recovery phrase and keep it in a safe place. The recovery phrase can be used to restore your wallet. Keep it carefully to not lose your assets.')}
       </Warning>
       <Grid item sx={{ mt: '55px', ml: '5px' }}>
         <Checkbox
           checked={isMnemonicSaved}
           iconStyle={{ transform: 'scale:(1.13)' }}
-          label={t<string>('I have saved my mnemonic seed safely.')}
+          label={t<string>('I have saved my recovery phrase safely.')}
           labelStyle={{ fontSize: '16px', marginLeft: '7px' }}
           onChange={() => setIsMnemonicSaved(!isMnemonicSaved)}
           style={{ ml: '15px', width: '92%' }}

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/components/CopySeedButton.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/components/CopySeedButton.tsx
@@ -1,0 +1,88 @@
+// Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import '@vaadin/icons';
+
+import { Grid, IconButton, Tooltip, Typography, useTheme } from '@mui/material';
+import React, { useCallback, useState } from 'react';
+import CopyToClipboard from 'react-copy-to-clipboard';
+
+import { useTranslation } from '../../../hooks';
+
+interface Props {
+  value: string;
+  copyText?: string | null | undefined;
+  iconSize?: number;
+}
+
+function CopySeedButton({ copyText, iconSize = 20, value }: Props): React.ReactElement<Props> {
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  const [copied, setCopy] = useState<boolean>(false);
+
+  const _onCopy = useCallback(() => {
+    setCopy(true);
+  }, []);
+
+  const handelCloseToolTip = useCallback(() => {
+    setTimeout(() => setCopy(false), 200);
+  }, []);
+
+  return (
+    <Grid item>
+      <Tooltip
+        arrow={!copied}
+        componentsProps={{
+          popper: {
+            sx: {
+              '.MuiTooltip-tooltip.MuiTooltip-tooltipPlacementTop.css-18kejt8': {
+                mb: '3px',
+                p: '3px 15px'
+              },
+              '.MuiTooltip-tooltip.MuiTooltip-tooltipPlacementTop.css-1yuxi3g': {
+                mb: '3px',
+                p: '3px 15px'
+              },
+              visibility: copied ? 'visible' : 'hidden'
+            }
+          },
+          tooltip: {
+            sx: {
+              '& .MuiTooltip-arrow': {
+                color: 'text.primary',
+                height: '10px'
+              },
+              backgroundColor: 'text.primary',
+              color: 'text.secondary',
+              fontSize: copied ? '16px' : '14px',
+              fontWeight: 400
+            }
+          }
+        }}
+        leaveDelay={700}
+        onClose={handelCloseToolTip}
+        placement='top'
+        title={t<string>('Copied')}
+      >
+        <IconButton
+          onClick={_onCopy}
+          sx={{ borderRadius: '5px', m: '5px', p: '2px' }}
+        >
+          <CopyToClipboard text={value}>
+            <Grid alignItems='center' container item width='fit-content'>
+              <vaadin-icon icon='vaadin:copy-o' style={{ color: `${theme.palette.secondary.light}`, width: `${iconSize}px` }} />
+              <Typography fontSize='16px' fontWeight={400} sx={{ pl: '8px', textDecoration: 'underline' }}>
+                {copyText ?? 'Copy to clipboard'}
+              </Typography>
+            </Grid>
+          </CopyToClipboard>
+        </IconButton>
+      </Tooltip>
+    </Grid>
+  );
+}
+
+export default (CopySeedButton);

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/components/CopySeedButton.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/components/CopySeedButton.tsx
@@ -5,7 +5,7 @@
 
 import '@vaadin/icons';
 
-import { Grid, IconButton, Tooltip, Typography, useTheme } from '@mui/material';
+import { Grid, IconButton, SxProps, Theme, Tooltip, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
@@ -15,9 +15,10 @@ interface Props {
   value: string;
   copyText?: string | null | undefined;
   iconSize?: number;
+  style?: SxProps<Theme>;
 }
 
-function CopySeedButton({ copyText, iconSize = 20, value }: Props): React.ReactElement<Props> {
+function CopySeedButton ({ copyText, iconSize = 20, style, value }: Props): React.ReactElement<Props> {
   const theme = useTheme();
   const { t } = useTranslation();
 
@@ -34,7 +35,7 @@ function CopySeedButton({ copyText, iconSize = 20, value }: Props): React.ReactE
   }, []);
 
   return (
-    <Grid item>
+    <Grid container item sx={style}>
       <Tooltip
         arrow={!copied}
         componentsProps={{

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/components/CopySeedButton.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/components/CopySeedButton.tsx
@@ -3,8 +3,8 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
+import { faCopy } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Grid, IconButton, SxProps, Theme, Tooltip, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
@@ -18,7 +18,7 @@ interface Props {
   style?: SxProps<Theme>;
 }
 
-function CopySeedButton ({ copyText, iconSize = 20, style, value }: Props): React.ReactElement<Props> {
+function CopySeedButton({ copyText, iconSize = 20, style, value }: Props): React.ReactElement<Props> {
   const theme = useTheme();
   const { t } = useTranslation();
 
@@ -76,7 +76,11 @@ function CopySeedButton ({ copyText, iconSize = 20, style, value }: Props): Reac
         >
           <CopyToClipboard text={value}>
             <Grid alignItems='center' container item width='fit-content'>
-              <vaadin-icon icon='vaadin:copy-o' style={{ color: `${theme.palette.secondary.light}`, width: `${iconSize}px` }} />
+              <FontAwesomeIcon
+                color={theme.palette.secondary.light}
+                fontSize={iconSize}
+                icon={faCopy}
+              />
               <Typography fontSize='16px' fontWeight={400} sx={{ pl: '8px', textDecoration: 'underline' }}>
                 {copyText ?? 'Copy to clipboard'}
               </Typography>

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/components/CopySeedButton.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/components/CopySeedButton.tsx
@@ -28,7 +28,9 @@ function CopySeedButton({ copyText, iconSize = 20, value }: Props): React.ReactE
   }, []);
 
   const handelCloseToolTip = useCallback(() => {
-    setTimeout(() => setCopy(false), 200);
+    const timer = setTimeout(() => setCopy(false), 200);
+
+    return () => clearTimeout(timer);
   }, []);
 
   return (

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/components/DownloadSeedButton.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/components/DownloadSeedButton.tsx
@@ -1,0 +1,53 @@
+// Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import '@vaadin/icons';
+
+import DownloadIcon from '@mui/icons-material/Download';
+import { Grid, IconButton, SxProps, Theme, Typography } from '@mui/material';
+import React, { useCallback } from 'react';
+
+import { useTranslation } from '../../../hooks';
+
+interface Props {
+  value: string;
+  text?: string | null | undefined;
+  iconSize?: number;
+  style?: SxProps<Theme>;
+}
+
+function DownloadSeedButton ({ iconSize = 30, style, text, value }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+
+  const onDownload = useCallback(() => {
+    const element = document.createElement('a');
+    const file = new Blob([value], { type: 'text/plain' });
+
+    element.href = URL.createObjectURL(file);
+    element.download = 'your-recovery-phrase.txt';
+    document.body.appendChild(element);
+    element.click();
+  }, [value]);
+
+  return (
+    <Grid container item sx={style}>
+      <IconButton
+        onClick={onDownload}
+        sx={{ borderRadius: '5px', m: '5px', p: '2px' }}
+      >
+        <Grid alignItems='center' container item width='fit-content'>
+          <DownloadIcon
+            sx={{ color: 'secondary.light', fontSize: `${iconSize}px` }}
+          />
+          <Typography fontSize='16px' fontWeight={400} sx={{ pl: '8px', textDecoration: 'underline' }}>
+            {t<string>(text ?? 'Download')}
+          </Typography>
+        </Grid>
+      </IconButton>
+    </Grid>
+  );
+}
+
+export default (DownloadSeedButton);

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/components/DownloadSeedButton.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/components/DownloadSeedButton.tsx
@@ -3,11 +3,10 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
-import DownloadIcon from '@mui/icons-material/Download';
-import { Grid, IconButton, SxProps, Theme, Typography } from '@mui/material';
-import React, { useCallback } from 'react';
+import { faFileDownload } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Grid, IconButton, SxProps, Theme, Typography, useTheme } from '@mui/material';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { useTranslation } from '../../../hooks';
 
@@ -16,10 +15,13 @@ interface Props {
   text?: string | null | undefined;
   iconSize?: number;
   style?: SxProps<Theme>;
+  bouncingTimeInSec?: number;
 }
 
-function DownloadSeedButton ({ iconSize = 30, style, text, value }: Props): React.ReactElement<Props> {
+function DownloadSeedButton({ bouncingTimeInSec = 3, iconSize = 23, style, text, value }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
+  const theme = useTheme();
+  const [isBouncing, setIsBouncing] = useState<boolean>(true);
 
   const onDownload = useCallback(() => {
     const element = document.createElement('a');
@@ -31,6 +33,10 @@ function DownloadSeedButton ({ iconSize = 30, style, text, value }: Props): Reac
     element.click();
   }, [value]);
 
+  useEffect(() => {
+    setTimeout(() => setIsBouncing(false), bouncingTimeInSec * 1000);
+  }, [bouncingTimeInSec]);
+
   return (
     <Grid container item sx={style}>
       <IconButton
@@ -38,8 +44,11 @@ function DownloadSeedButton ({ iconSize = 30, style, text, value }: Props): Reac
         sx={{ borderRadius: '5px', m: '5px', p: '2px' }}
       >
         <Grid alignItems='center' container item width='fit-content'>
-          <DownloadIcon
-            sx={{ color: 'secondary.light', fontSize: `${iconSize}px` }}
+          <FontAwesomeIcon
+            bounce={isBouncing}
+            color={theme.palette.secondary.light}
+            fontSize={iconSize}
+            icon={faFileDownload}
           />
           <Typography fontSize='16px' fontWeight={400} sx={{ pl: '8px', textDecoration: 'underline' }}>
             {t<string>(text ?? 'Download')}

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/components/Passwords2.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/components/Passwords2.tsx
@@ -51,7 +51,6 @@ export default function Passwords2 ({ firstPassStyle, secondPassStyle, isFocusse
       <ValidatedInput2
         component={Password}
         dataInputRepeatPassword
-        // data-input-repeat-password
         label={t<string>('Repeat the password')}
         onEnter={onEnter}
         onValidatedChange={setPass2}

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/components/Passwords2.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/components/Passwords2.tsx
@@ -1,0 +1,65 @@
+// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { Password } from '../../../components';
+import { useTranslation } from '../../../hooks';
+import { allOf, isNotShorterThan, isSameAs, Validator } from '../../../util/validators';
+import ValidatedInput2 from './ValidatedInput2';
+
+interface Props {
+  isFocussed?: boolean;
+  label?: string;
+  onChange: (password: string | null) => void;
+  onEnter: () => void;
+  firstPassStyle?: React.CSSProperties;
+  secondPassStyle?: React.CSSProperties;
+}
+
+const MIN_LENGTH = 6;
+
+export default function Passwords2 ({ firstPassStyle, secondPassStyle, isFocussed, onChange, onEnter, label = undefined }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+  const [pass1, setPass1] = useState<string | null>(null);
+  const [pass2, setPass2] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState<boolean>(false);
+  const isFirstPasswordValid = useMemo(() => isNotShorterThan(MIN_LENGTH, t<string>('Password is too short')), [t]);
+  const isSecondPasswordValid = useCallback((firstPassword: string): Validator<string> => allOf(
+    isNotShorterThan(MIN_LENGTH, t<string>('Password is too short')),
+    isSameAs(firstPassword, t<string>('Password do not match'))
+  ), [t]);
+
+  useEffect((): void => {
+    onChange(pass1 && pass2 ? pass1 : null);
+  }, [onChange, pass1, pass2]);
+
+  return (
+    <>
+      <ValidatedInput2
+        component={Password}
+        data-input-password
+        isFocused={isFocussed}
+        label={label || t<string>('Password for this account (>5 characters)')}
+        onValidatedChange={setPass1}
+        setShowPassword={setShowPassword}
+        showPassword={showPassword}
+        style={firstPassStyle}
+        validator={isFirstPasswordValid}
+      />
+      <ValidatedInput2
+        component={Password}
+        dataInputRepeatPassword
+        // data-input-repeat-password
+        label={t<string>('Repeat the password')}
+        onEnter={onEnter}
+        onValidatedChange={setPass2}
+        setShowPassword={setShowConfirmPassword}
+        showPassword={showConfirmPassword}
+        style={secondPassStyle}
+        validator={isSecondPasswordValid(pass1)}
+      />
+    </>
+  );
+}

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/components/ValidatedInput2.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/components/ValidatedInput2.tsx
@@ -1,0 +1,98 @@
+// Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import { Grid, useTheme } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+
+import { Affirm, Warning } from '../../../components';
+import { useIsMounted, useTranslation } from '../../../hooks';
+import { Result, Validator } from '../../../util/validators';
+
+interface BasicProps {
+  isError?: boolean;
+  value?: string | null;
+  onChange?: (value: string) => void;
+}
+
+type Props<T extends BasicProps> = T & {
+  className?: string;
+  component: React.ComponentType<T>;
+  defaultValue?: string;
+  onValidatedChange: (value: string | null) => void;
+  validator: Validator<string>;
+  onEnter?: () => void;
+  isFocused?: boolean;
+  style?: React.CSSProperties;
+}
+
+function ValidatedInput2<T extends Record<string, unknown>>({ className, component: Input, defaultValue, isFocused, onEnter, onValidatedChange, style, validator, ...props }: Props<T>): React.ReactElement<Props<T>> {
+  const [value, setValue] = useState(defaultValue || '');
+  const [validationResult, setValidationResult] = useState<Result<string>>(Result.ok(''));
+  const isMounted = useIsMounted();
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (defaultValue) {
+      setValue(defaultValue);
+    }
+  }, [defaultValue]);
+
+  useEffect(() => {
+    // Do not show any error on first mount
+    if (!isMounted) {
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    (async (): Promise<void> => {
+      const result = await validator(value);
+
+      setValidationResult(result);
+      onValidatedChange(Result.isOk(result) ? value : null);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, validator, onValidatedChange]);
+
+  return (
+    <div
+      className={className}
+      style={style}
+    >
+      <Input
+        {...props as unknown as T}
+        isError={value && Result.isError(validationResult)}
+        isFocused={isFocused}
+        onChange={setValue}
+        onEnter={onEnter}
+        value={value}
+      />
+      {value && Result.isOk(validationResult) && props.dataInputRepeatPassword &&
+        <Grid container item sx={{ '> div.belowInput': { m: 0 }, height: '30px', width: '400px' }}>
+          <Affirm
+            isAffirm
+            isBelowInput
+            theme={theme}
+          >
+            {t<string>('Password match')}
+          </Affirm>
+        </Grid>
+      }
+      {value && Result.isError(validationResult) &&
+        <Grid container item sx={{ '> div.belowInput': { m: 0 }, height: '30px', width: '400px' }}>
+          <Warning
+            isBelowInput
+            isDanger
+            theme={theme}
+          >
+            {validationResult.error.errorDescription}
+          </Warning>
+        </Grid>
+      }
+    </div>
+  );
+}
+
+export default ValidatedInput2;

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
@@ -81,11 +81,11 @@ export default function CreateAccount(): React.ReactElement {
         {seed}
       </Grid>
       <Grid container item>
-        <CopySeedButton
+        <DownloadSeedButton
           style={{ width: 'fit-content' }}
           value={seed ?? ''}
         />
-        <DownloadSeedButton
+        <CopySeedButton
           style={{ width: 'fit-content' }}
           value={seed ?? ''}
         />

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
@@ -39,19 +39,6 @@ export default function CreateAccount(): React.ReactElement {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // useEffect((): void => {
-  //   if (seed) {
-  //     const type = chain && chain.definition.chainType === 'ethereum'
-  //       ? 'ethereum'
-  //       : DEFAULT_TYPE;
-
-  //     setType(type);
-  //     validateSeed(seed, type)
-  //       .then(({ address }) => setAddress(address))
-  //       .catch(console.error);
-  //   }
-  // }, [seed, chain]);
-
   const onNameChange = useCallback((enteredName: string) => {
     // Remove leading white spaces
     const trimmedName = enteredName.replace(/^\s+/, '');
@@ -97,8 +84,6 @@ export default function CreateAccount(): React.ReactElement {
       />
     </Grid>
   );
-
-  console.log('name:', name)
 
   return (
     <Grid bgcolor={indexBgColor} container item justifyContent='center'>

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
@@ -74,7 +74,7 @@ export default function CreateAccount(): React.ReactElement {
   const MnemonicSeedDisplay = ({ style }: { style?: SxProps<Theme> }) => (
     <Grid container display='block' item sx={style}>
       <Typography fontSize='16px' fontWeight={400}>
-        {t<string>('Generated 12-word Mnemonic seed')}
+        {t<string>('Generated 12-word recovery phrase')}
       </Typography>
       <Grid container item sx={{ bgcolor: 'background.paper', border: '1px solid', borderColor: 'secondary.light', borderRadius: '5px', fontSize: '18px', fontWeight: 400, p: '8px 12px' }}>
         {seed}
@@ -104,7 +104,7 @@ export default function CreateAccount(): React.ReactElement {
             </Grid>
           </Grid>
           <Typography fontSize='16px' fontWeight={400} width='100%'>
-            {t<string>('In order to create a new account you are given a 12-word Mnemonic seed which needs to be recorded and saved in a safe place. The mnemonic can be used to restore your wallet. Keep it carefully to not lose your assets.')}
+            {t<string>('In order to create a new account you are given a 12-word recovery phrase which needs to be recorded and saved in a safe place. The recovery phrase can be used to restore your wallet. Keep it carefully to not lose your assets.')}
           </Typography>
           <MnemonicSeedDisplay style={{ my: '15px' }} />
           <InputWithLabel
@@ -127,7 +127,7 @@ export default function CreateAccount(): React.ReactElement {
               <Checkbox2
                 checked={isMnemonicSaved}
                 iconStyle={{ transform: 'scale(1.13)' }}
-                label={t<string>('I have saved my mnemonic seed safely.')}
+                label={t<string>('I have saved my recovery phrase safely.')}
                 labelStyle={{ fontSize: '18px', fontWeight: 300, marginLeft: '7px' }}
                 onChange={onCheck}
               />

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
@@ -114,7 +114,7 @@ export default function CreateAccount(): React.ReactElement {
           <Typography fontSize='16px' fontWeight={400} width='100%'>
             {t<string>('In order to create a new account you are given a 12-word recovery phrase which needs to be recorded and saved in a safe place. The recovery phrase can be used to restore your wallet. Keep it carefully to not lose your assets.')}
           </Typography>
-          <MnemonicSeedDisplay />
+          <MnemonicSeedDisplay style={{ marginBlock: '20px' }} />
           <InputWithLabel
             isError={name === null || name?.length === 0}
             isFocused

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
@@ -14,6 +14,7 @@ import { createAccountSuri, createSeed } from '../../messaging';
 import { FullScreenHeader } from '../governance/FullScreenHeader';
 import CopySeedButton from './components/CopySeedButton';
 import Passwords2 from './components/Passwords2';
+import DownloadSeedButton from './components/DownloadSeedButton';
 
 export default function CreateAccount(): React.ReactElement {
   useFullscreen();
@@ -79,9 +80,16 @@ export default function CreateAccount(): React.ReactElement {
       <Grid container item sx={{ bgcolor: 'background.paper', border: '1px solid', borderColor: 'secondary.light', borderRadius: '5px', fontSize: '18px', fontWeight: 400, p: '8px 12px' }}>
         {seed}
       </Grid>
-      <CopySeedButton
-        value={seed ?? ''}
-      />
+      <Grid container item>
+        <CopySeedButton
+          style={{ width: 'fit-content' }}
+          value={seed ?? ''}
+        />
+        <DownloadSeedButton
+          style={{ width: 'fit-content' }}
+          value={seed ?? ''}
+        />
+      </Grid>
     </Grid>
   );
 
@@ -106,7 +114,7 @@ export default function CreateAccount(): React.ReactElement {
           <Typography fontSize='16px' fontWeight={400} width='100%'>
             {t<string>('In order to create a new account you are given a 12-word recovery phrase which needs to be recorded and saved in a safe place. The recovery phrase can be used to restore your wallet. Keep it carefully to not lose your assets.')}
           </Typography>
-          <MnemonicSeedDisplay style={{ my: '15px' }} />
+          <MnemonicSeedDisplay />
           <InputWithLabel
             isError={name === null || name?.length === 0}
             isFocused

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
@@ -1,0 +1,164 @@
+// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import '@vaadin/icons';
+
+import { Grid, SxProps, Theme, Typography, useTheme } from '@mui/material';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import { ActionContext, Checkbox2, InputWithLabel, PButton } from '../../components';
+import { useFullscreen, useTranslation } from '../../hooks';
+import { createAccountSuri, createSeed } from '../../messaging';
+import { FullScreenHeader } from '../governance/FullScreenHeader';
+import CopySeedButton from './components/CopySeedButton';
+import Passwords2 from './components/Passwords2';
+
+export default function CreateAccount(): React.ReactElement {
+  useFullscreen();
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const onAction = useContext(ActionContext);
+
+  const [seed, setSeed] = useState<null | string>(null);
+  const [name, setName] = useState<string | null | undefined>();
+  const [password, setPassword] = useState<string | null>(null);
+  const [isBusy, setIsBusy] = useState<boolean>(false);
+  const [isMnemonicSaved, setIsMnemonicSaved] = useState(false);
+
+  const indexBgColor = useMemo(() => theme.palette.mode === 'light' ? '#DFDFDF' : theme.palette.background.paper, [theme.palette]);
+  const contentBgColor = useMemo(() => theme.palette.mode === 'light' ? '#F1F1F1' : theme.palette.background.default, [theme.palette]);
+
+  useEffect((): void => {
+    createSeed(undefined)
+      .then(({ seed }): void => {
+        setSeed(seed);
+      })
+      .catch(console.error);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // useEffect((): void => {
+  //   if (seed) {
+  //     const type = chain && chain.definition.chainType === 'ethereum'
+  //       ? 'ethereum'
+  //       : DEFAULT_TYPE;
+
+  //     setType(type);
+  //     validateSeed(seed, type)
+  //       .then(({ address }) => setAddress(address))
+  //       .catch(console.error);
+  //   }
+  // }, [seed, chain]);
+
+  const onNameChange = useCallback((enteredName: string) => {
+    // Remove leading white spaces
+    const trimmedName = enteredName.replace(/^\s+/, '');
+
+    // Remove multiple consecutive spaces in the middle or at the end
+    const cleanedName = trimmedName.replace(/\s{2,}/g, ' ');
+
+    setName(cleanedName);
+  }, []);
+
+  const onPasswordChange = useCallback((enteredPassword: string | null) => {
+    setPassword(enteredPassword);
+  }, []);
+
+  const onCheck = useCallback(() => {
+    setIsMnemonicSaved(!isMnemonicSaved);
+  }, [isMnemonicSaved]);
+
+  const onCreate = useCallback((): void => {
+    // this should always be the case
+    if (name && password && seed) {
+      setIsBusy(true);
+
+      createAccountSuri(name, password, seed)
+        .then(() => onAction('/'))
+        .catch((error: Error): void => {
+          setIsBusy(false);
+          console.error(error);
+        });
+    }
+  }, [name, onAction, password, seed]);
+
+  const MnemonicSeedDisplay = ({ style }: { style?: SxProps<Theme> }) => (
+    <Grid container display='block' item sx={style}>
+      <Typography fontSize='16px' fontWeight={400}>
+        {t<string>('Generated 12-word Mnemonic seed')}
+      </Typography>
+      <Grid container item sx={{ bgcolor: 'background.paper', border: '1px solid', borderColor: 'secondary.light', borderRadius: '5px', fontSize: '18px', fontWeight: 400, p: '8px 12px' }}>
+        {seed}
+      </Grid>
+      <CopySeedButton
+        value={seed ?? ''}
+      />
+    </Grid>
+  );
+
+  console.log('name:', name)
+
+  return (
+    <Grid bgcolor={indexBgColor} container item justifyContent='center'>
+      <FullScreenHeader
+        noAccountDropDown
+        noChainSwitch
+      />
+      <Grid container item justifyContent='center' sx={{ bgcolor: contentBgColor, height: 'calc(100vh - 70px)', maxWidth: '840px', overflow: 'scroll' }}>
+        <Grid container item sx={{ display: 'block', px: '10%' }}>
+          <Grid alignContent='center' alignItems='center' container item>
+            <Grid item sx={{ mr: '20px' }}>
+              <vaadin-icon icon='vaadin:plus-circle-o' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
+            </Grid>
+            <Grid item>
+              <Typography fontSize='30px' fontWeight={700} py='20px' width='100%'>
+                {t<string>('Create a new account')}
+              </Typography>
+            </Grid>
+          </Grid>
+          <Typography fontSize='16px' fontWeight={400} width='100%'>
+            {t<string>('In order to create a new account you are given a 12-word Mnemonic seed which needs to be recorded and saved in a safe place. The mnemonic can be used to restore your wallet. Keep it carefully to not lose your assets.')}
+          </Typography>
+          <MnemonicSeedDisplay style={{ my: '15px' }} />
+          <InputWithLabel
+            isError={name === null || name?.length === 0}
+            isFocused
+            label={t<string>('Choose a name for this account')}
+            onChange={onNameChange}
+            value={name ?? ''}
+
+          />
+          <Passwords2
+            firstPassStyle={{ marginBlock: '10px' }}
+            label={t<string>('Password for this account (more than 5 characters)')}
+            onChange={onPasswordChange}
+            // eslint-disable-next-line react/jsx-no-bind
+            onEnter={isMnemonicSaved && password ? onCreate : () => null}
+          />
+          <Grid alignItems='center' container item pt='40px'>
+            <Grid container item xs={8}>
+              <Checkbox2
+                checked={isMnemonicSaved}
+                iconStyle={{ transform: 'scale(1.13)' }}
+                label={t<string>('I have saved my mnemonic seed safely.')}
+                labelStyle={{ fontSize: '18px', fontWeight: 300, marginLeft: '7px' }}
+                onChange={onCheck}
+              />
+            </Grid>
+            <Grid container item xs={4}>
+              <PButton
+                _isBusy={isBusy}
+                _mt='1px'
+                _onClick={onCreate}
+                disabled={!(name && password && seed && isMnemonicSaved)}
+                text={t<string>('Create account')}
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+}

--- a/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/createAccountFullScreen/index.tsx
@@ -13,8 +13,8 @@ import { useFullscreen, useTranslation } from '../../hooks';
 import { createAccountSuri, createSeed } from '../../messaging';
 import { FullScreenHeader } from '../governance/FullScreenHeader';
 import CopySeedButton from './components/CopySeedButton';
-import Passwords2 from './components/Passwords2';
 import DownloadSeedButton from './components/DownloadSeedButton';
+import Passwords2 from './components/Passwords2';
 
 export default function CreateAccount(): React.ReactElement {
   useFullscreen();
@@ -103,7 +103,7 @@ export default function CreateAccount(): React.ReactElement {
         <Grid container item sx={{ display: 'block', px: '10%' }}>
           <Grid alignContent='center' alignItems='center' container item>
             <Grid item sx={{ mr: '20px' }}>
-              <vaadin-icon icon='vaadin:plus-circle-o' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
+              <vaadin-icon icon='vaadin:plus-circle' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
             </Grid>
             <Grid item>
               <Typography fontSize='30px' fontWeight={700} py='20px' width='100%'>

--- a/packages/extension-polkagate/src/popup/deriveAccount/index.tsx
+++ b/packages/extension-polkagate/src/popup/deriveAccount/index.tsx
@@ -96,7 +96,7 @@ function Derive({ isLocked }: Props): React.ReactElement<Props> {
         textAlign='left'
         width='88%'
       >
-        {t<string>('A derived account inherits the mnemonic from its parent, but has a unique derivation path.')}
+        {t<string>('A derived account inherits the recovery phrase from its parent, but has a unique derivation path.')}
       </Typography>
       {stepOne && !account && (
         <>

--- a/packages/extension-polkagate/src/popup/forgetAccount/index.tsx
+++ b/packages/extension-polkagate/src/popup/forgetAccount/index.tsx
@@ -93,7 +93,7 @@ function ForgetAccount({ match: { params: { address, isExternal } } }: Props): R
           marginTop={0}
           theme={theme}
         >
-          {t('Removing this account means losing access via this extension. To recover it later, use the mnemonic seed.')}
+          {t('Removing this account means losing access via this extension. To recover it later, use the recovery phrase.')}
         </Warning>
       </Grid>
       <Grid m='40px auto 0' width='92%'>

--- a/packages/extension-polkagate/src/popup/governance/FullScreenHeader.tsx
+++ b/packages/extension-polkagate/src/popup/governance/FullScreenHeader.tsx
@@ -16,8 +16,13 @@ import AddressDropdown from './components/AddressDropdown';
 import ThemeChanger from './partials/ThemeChanger';
 import { MAX_WIDTH } from './utils/consts';
 
-export function FullScreenHeader({ page }: { page: 'governance' | 'manageIdentity' | 'send' | 'socialRecovery' }): React.ReactElement {
+interface Props {
+  page?: 'governance' | 'manageIdentity' | 'send' | 'socialRecovery';
+  noChainSwitch?: boolean;
+  noAccountDropDown?: boolean;
+}
 
+export function FullScreenHeader({ noAccountDropDown = false, noChainSwitch = false, page }: Props): React.ReactElement {
   const { address, postId, topMenu } = useParams<{ address: string, topMenu?: 'referenda' | 'fellowship', postId?: string }>();
 
   const api = useApi(address);
@@ -57,26 +62,31 @@ export function FullScreenHeader({ page }: { page: 'governance' | 'manageIdentit
             <Grid container item justifyContent='flex-end' width='fit-content'>
               <ThemeChanger />
             </Grid>
-            <Grid container item justifyContent='flex-end' sx={{ color: 'text.primary', maxWidth: 'calc(100% - 130px)', px: '15px', width: 'fit-content' }}>
-              <AddressDropdown
-                api={api}
-                chainGenesis={chain?.genesisHash}
-                height='40px'
-                onSelect={onAccountChange}
-                selectedAddress={address}
-              />
-            </Grid>
-            <Grid container item justifyContent='flex-end' width='50px'>
-              <FullScreenChainSwitch
-                address={address}
-                chains={filteredChains}
-              />
-            </Grid>
-            <Grid container item justifyContent='flex-end' width='50px'>
-              <FullScreenRemoteNode
-                address={address}
-              />
-            </Grid>
+            {!noAccountDropDown &&
+              <Grid container item justifyContent='flex-end' sx={{ color: 'text.primary', maxWidth: 'calc(100% - 130px)', px: '15px', width: 'fit-content' }}>
+                <AddressDropdown
+                  api={api}
+                  chainGenesis={chain?.genesisHash}
+                  height='40px'
+                  onSelect={onAccountChange}
+                  selectedAddress={address}
+                />
+              </Grid>}
+            {!noChainSwitch &&
+              <>
+                <Grid container item justifyContent='flex-end' width='50px'>
+                  <FullScreenChainSwitch
+                    address={address}
+                    chains={filteredChains}
+                  />
+                </Grid>
+                <Grid container item justifyContent='flex-end' width='50px'>
+                  <FullScreenRemoteNode
+                    address={address}
+                  />
+                </Grid>
+              </>
+            }
           </Grid>
         </Grid>
       </Container>

--- a/packages/extension-polkagate/src/popup/import/importSeed/SeedAndPath.tsx
+++ b/packages/extension-polkagate/src/popup/import/importSeed/SeedAndPath.tsx
@@ -59,8 +59,8 @@ export default function SeedAndPath({ className, onAccountChange, onNextStep, ty
         setAddress('');
         onAccountChange(null);
         setError(path
-          ? t<string>('Invalid mnemonic seed or derivation path')
-          : t<string>('Invalid mnemonic seed')
+          ? t<string>('Invalid recovery phrase or derivation path')
+          : t<string>('Invalid recovery phrase')
         );
       });
   }, [t, genesis, seed, path, onAccountChange, type]);
@@ -88,7 +88,7 @@ export default function SeedAndPath({ className, onAccountChange, onNextStep, ty
           fontSize='18px'
           isError={!!error}
           isFocused
-          label={t<string>('Existing 12 or 24-word mnemonic seed')}
+          label={t<string>('Existing 12 or 24-word recovery phrase')}
           onChange={setSeed}
           rowsCount={2}
           value={seed || ''}

--- a/packages/extension-polkagate/src/popup/welcome/AddAccount.tsx
+++ b/packages/extension-polkagate/src/popup/welcome/AddAccount.tsx
@@ -84,7 +84,7 @@ function AddAccount(): React.ReactElement {
         _mt='10px'
         _onClick={_goToImport}
         _variant={'outlined'}
-        text={t<string>('Import from mnemonic')}
+        text={t<string>('Import from recovery phrase')}
       />
       <PButton
         _mt='10px'

--- a/packages/extension-polkagate/src/popup/welcome/AddAccount.tsx
+++ b/packages/extension-polkagate/src/popup/welcome/AddAccount.tsx
@@ -32,8 +32,9 @@ function AddAccount(): React.ReactElement {
   );
 
   const _goToCreate = useCallback(
-    () => onAction('/account/create'),
-    [onAction]
+    (): void => {
+      windowOpen('/account/create').catch(console.error);
+    }, []
   );
 
   const _goToAddAddressOnly = useCallback(

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -18,7 +18,7 @@ import { subscribeAccounts, subscribeAuthorizeRequests, subscribeMetadataRequest
 import Account from '../../../extension-polkagate/src/popup/account';
 import AuthList from '../../../extension-polkagate/src/popup/authManagement';
 import Authorize from '../../../extension-polkagate/src/popup/authorize/index';
-import CreateAccount from '../../../extension-polkagate/src/popup/createAccount';
+import CreateAccount from '../../../extension-polkagate/src/popup/createAccountFullScreen';
 import CrowdLoans from '../../../extension-polkagate/src/popup/crowdloans';
 import Derive from '../../../extension-polkagate/src/popup/deriveAccount';
 import Export from '../../../extension-polkagate/src/popup/export/Export';


### PR DESCRIPTION
## Works Done:

1. Add new path
2. Create new directory `popup/createAccountFullScreen`
3. Update `FullScreenHeader.tsx`

#851 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new account creation process with enhanced security measures. Users can now generate a 12-word recovery phrase, which can be copied to the clipboard or downloaded as a text file for secure storage.
- New Feature: Introduced `CopySeedButton` and `DownloadSeedButton` components for copying and downloading the recovery phrase respectively.
- Refactor: Updated various components to replace the term "mnemonic seed" with "recovery phrase" for improved clarity.
- Refactor: Enhanced flexibility in rendering header components by introducing optional props in `FullScreenHeader`.
- Chore: Improved error handling when opening new windows in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->