### PR TITLE
UseUnSupportedNetwork for staking pages (Solo, Pool)

### DIFF
--- a/packages/extension-polkagate/src/hooks/index.ts
+++ b/packages/extension-polkagate/src/hooks/index.ts
@@ -74,3 +74,4 @@ export { default as useAccountsInfo } from './useAccountsInfo';
 export { default as useActiveRecoveries } from './useActiveRecoveries';
 export { default as useLostAccountInformation } from './useLostAccountInformation';
 export { default as useCanPayFeeAndDeposit } from './useCanPayFeeAndDeposit';
+export { default as useUnSupportedNetwork } from './useUnSupportedNetwork';

--- a/packages/extension-polkagate/src/hooks/useUnSupportedNetwork.ts
+++ b/packages/extension-polkagate/src/hooks/useUnSupportedNetwork.ts
@@ -1,0 +1,20 @@
+// Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from 'react';
+
+import useChain from './useChain';
+
+export default function useUnSupportedNetwork (address: string | undefined, supportedChains: string[] | undefined, cbFunction: () => void): void {
+  const chain = useChain(address);
+
+  useEffect(() => {
+    if (!address || !supportedChains || supportedChains.length === 0 || !chain || !chain.genesisHash || supportedChains.includes(chain.genesisHash)) {
+      return;
+    }
+
+    if (!(supportedChains.includes(chain.genesisHash))) {
+      return cbFunction();
+    }
+  }, [address, cbFunction, chain, supportedChains]);
+}

--- a/packages/extension-polkagate/src/hooks/useUnSupportedNetwork.ts
+++ b/packages/extension-polkagate/src/hooks/useUnSupportedNetwork.ts
@@ -1,12 +1,14 @@
 // Copyright 2019-2023 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 
+import { ActionContext } from '../components';
 import useChain from './useChain';
 
-export default function useUnSupportedNetwork (address: string | undefined, supportedChains: string[] | undefined, cbFunction: () => void): void {
+export default function useUnSupportedNetwork(address: string | undefined, supportedChains: string[] | undefined, cbFunction?: () => void): void {
   const chain = useChain(address);
+  const onAction = useContext(ActionContext);
 
   useEffect(() => {
     if (!address || !supportedChains || supportedChains.length === 0 || !chain || !chain.genesisHash || supportedChains.includes(chain.genesisHash)) {
@@ -14,7 +16,7 @@ export default function useUnSupportedNetwork (address: string | undefined, supp
     }
 
     if (!(supportedChains.includes(chain.genesisHash))) {
-      return cbFunction();
+      return cbFunction ? cbFunction() : onAction('/');
     }
-  }, [address, cbFunction, chain, supportedChains]);
+  }, [address, cbFunction, chain, onAction, supportedChains]);
 }

--- a/packages/extension-polkagate/src/popup/account/index.tsx
+++ b/packages/extension-polkagate/src/popup/account/index.tsx
@@ -217,7 +217,7 @@ export default function AccountDetails(): React.ReactElement {
               </>
             }
           </Grid>
-          : <StakingOption showStakingOptions={showStakingOptions} />
+          : <StakingOption showStakingOptions={showStakingOptions} setShowStakingOptions={setShowStakingOptions} />
         }
         <Grid container justifyContent='space-around' sx={{ bgcolor: 'background.default', borderTop: '2px solid', borderTopColor: 'secondary.main', bottom: 0, height: '62px', left: '4%', position: 'absolute', pt: '7px', pb: '5px', width: '92%' }} >
           <HorizontalMenuItem

--- a/packages/extension-polkagate/src/popup/staking/Options.tsx
+++ b/packages/extension-polkagate/src/popup/staking/Options.tsx
@@ -9,20 +9,24 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { BN, bnMax } from '@polkadot/util';
 
 import { poolStakingBlack, poolStakingWhite, soloStakingBlack, soloStakingWhite } from '../../assets/icons';
-import { useApi, useMinToReceiveRewardsInSolo, usePoolConsts, useStakingConsts, useTranslation } from '../../hooks';
+import { useApi, useMinToReceiveRewardsInSolo, usePoolConsts, useStakingConsts, useTranslation, useUnSupportedNetwork } from '../../hooks';
+import { STAKING_CHAINS } from '../../util/constants';
 import Option from './partial/StakingOption';
 
 interface Props {
-  showStakingOptions: boolean
+  showStakingOptions: boolean;
+  setShowStakingOptions: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function Options({ showStakingOptions }: Props): React.ReactElement {
+export default function Options ({ setShowStakingOptions, showStakingOptions }: Props): React.ReactElement {
   const { t } = useTranslation();
   const history = useHistory();
   const theme = useTheme();
   const { pathname, state } = useLocation();
   const { address } = useParams<{ address: string }>();
   const api = useApi(address, state?.api);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => setShowStakingOptions(false));
   const stakingConsts = useStakingConsts(address);
   const poolConsts = usePoolConsts(address);
   const nominatorInfo = useMinToReceiveRewardsInSolo(address);

--- a/packages/extension-polkagate/src/popup/staking/pool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/index.tsx
@@ -19,10 +19,10 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { BN, BN_ZERO } from '@polkadot/util';
 
 import { ActionContext, FormatBalance, FormatBalance2, HorizontalMenuItem, Identicon, ShowBalance } from '../../../components';
-import { useApi, useBalances, useChain, useDecimal, useFormatted, useMyAccountIdentity, usePool, usePoolConsts, useStakingConsts, useToken, useTranslation } from '../../../hooks';
+import { useApi, useBalances, useChain, useDecimal, useFormatted, useMyAccountIdentity, usePool, usePoolConsts, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../hooks';
 import { ChainSwitch, HeaderBrand } from '../../../partials';
 import BouncingSubTitle from '../../../partials/BouncingSubTitle';
-import { BALANCES_VALIDITY_PERIOD, DATE_OPTIONS, TIME_TO_SHAKE_ICON } from '../../../util/constants';
+import { BALANCES_VALIDITY_PERIOD, DATE_OPTIONS, STAKING_CHAINS, TIME_TO_SHAKE_ICON } from '../../../util/constants';
 import AccountBrief from '../../account/AccountBrief';
 import { getValue } from '../../account/util';
 import RewardsStakeReview from './rewards/Stake';
@@ -52,6 +52,9 @@ export default function Index(): React.ReactElement {
   const formatted = useFormatted(address);
   const chain = useChain(address);
   const api = useApi(address, state?.api);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+
   const [refresh, setRefresh] = useState<boolean>(false);
   const pool = usePool(address, undefined, refresh);
   const stakingConsts = useStakingConsts(address, state?.stakingConsts);

--- a/packages/extension-polkagate/src/popup/staking/pool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/index.tsx
@@ -12,13 +12,13 @@ import { faHand, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
 import { Container, Divider, Grid, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN, BN_ZERO } from '@polkadot/util';
 
-import { ActionContext, FormatBalance, FormatBalance2, HorizontalMenuItem, Identicon, ShowBalance } from '../../../components';
+import { FormatBalance, FormatBalance2, HorizontalMenuItem, Identicon, ShowBalance } from '../../../components';
 import { useApi, useBalances, useChain, useDecimal, useFormatted, useMyAccountIdentity, usePool, usePoolConsts, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../hooks';
 import { ChainSwitch, HeaderBrand } from '../../../partials';
 import BouncingSubTitle from '../../../partials/BouncingSubTitle';
@@ -44,7 +44,6 @@ interface State {
 
 export default function Index(): React.ReactElement {
   const { t } = useTranslation();
-  const onAction = useContext(ActionContext);
   const theme = useTheme();
   const history = useHistory();
   const { pathname, state } = useLocation<State>();
@@ -53,7 +52,7 @@ export default function Index(): React.ReactElement {
   const chain = useChain(address);
   const api = useApi(address, state?.api);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
 
   const [refresh, setRefresh] = useState<boolean>(false);
   const pool = usePool(address, undefined, refresh);

--- a/packages/extension-polkagate/src/popup/staking/pool/myPool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/myPool/index.tsx
@@ -11,11 +11,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIos as ArrowForwardIosIcon, AutoDelete as AutoDeleteIcon, KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon, KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon, LockOpenRounded as UnblockIcon, LockPersonRounded as BlockIcon } from '@mui/icons-material';
 import { Divider, Grid, Typography, useTheme } from '@mui/material';
 import { Circle } from 'better-react-spinkit';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
-import { ActionContext, PButton, Select, Warning } from '../../../../components';
+import { PButton, Select, Warning } from '../../../../components';
 import { useApi, useChain, useFormatted, useMyPools, usePool, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
 import { STAKING_CHAINS } from '../../../../util/constants';
@@ -58,9 +58,8 @@ export default function Pool (): React.ReactElement {
   const history = useHistory();
   const chain = useChain(address);
   const formatted = useFormatted(address);
-  const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
   const myOtherPools = useMyPools(address);
 
   const [poolIndex, setPoolIndex] = useState<number>(0);

--- a/packages/extension-polkagate/src/popup/staking/pool/myPool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/myPool/index.tsx
@@ -8,17 +8,17 @@ import type { MyPoolInfo } from '../../../../util/types';
 
 import { faPenToSquare, faPersonCircleXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
-import { AutoDelete as AutoDeleteIcon, KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon, KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon, LockOpenRounded as UnblockIcon, LockPersonRounded as BlockIcon } from '@mui/icons-material';
+import { ArrowForwardIos as ArrowForwardIosIcon, AutoDelete as AutoDeleteIcon, KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon, KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon, LockOpenRounded as UnblockIcon, LockPersonRounded as BlockIcon } from '@mui/icons-material';
 import { Divider, Grid, Typography, useTheme } from '@mui/material';
 import { Circle } from 'better-react-spinkit';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
-import { PButton, Select, Warning } from '../../../../components';
-import { useApi, useChain, useFormatted, useMyPools, usePool, useTranslation } from '../../../../hooks';
+import { ActionContext, PButton, Select, Warning } from '../../../../components';
+import { useApi, useChain, useFormatted, useMyPools, usePool, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
+import { STAKING_CHAINS } from '../../../../util/constants';
 import ShowPool from '../../partial/ShowPool';
 import ShowRoles from '../../partial/ShowRoles';
 import EditPool from './editPool';
@@ -46,7 +46,7 @@ interface ArrowsProps {
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => { };
 
-export default function Pool(): React.ReactElement {
+export default function Pool (): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
 
@@ -58,6 +58,9 @@ export default function Pool(): React.ReactElement {
   const history = useHistory();
   const chain = useChain(address);
   const formatted = useFormatted(address);
+  const onAction = useContext(ActionContext);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
   const myOtherPools = useMyPools(address);
 
   const [poolIndex, setPoolIndex] = useState<number>(0);

--- a/packages/extension-polkagate/src/popup/staking/pool/nominations/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/nominations/index.tsx
@@ -10,16 +10,17 @@ import type { MyPoolInfo, PoolStakingConsts, StakingConsts, ValidatorInfo } from
 import { faRefresh } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Divider, Grid, SxProps, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { DeriveStakingQuery } from '@polkadot/api-derive/types';
 import { BN } from '@polkadot/util';
 
-import { Infotip, Motion, PButton, Progress, Warning } from '../../../../components';
-import { useApi, useChain, useFormatted, usePool, useStakingConsts, useTranslation, useValidators, useValidatorsIdentities } from '../../../../hooks';
+import { ActionContext, Infotip, Motion, PButton, Progress, Warning } from '../../../../components';
+import { useApi, useChain, useFormatted, usePool, useStakingConsts, useTranslation, useUnSupportedNetwork, useValidators, useValidatorsIdentities } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
+import { STAKING_CHAINS } from '../../../../util/constants';
 import SelectValidators from '../../partial/SelectValidators';
 import Review from '../../partial/SelectValidatorsReview';
 import ValidatorsTable from '../../partial/ValidatorsTable';
@@ -33,14 +34,18 @@ interface State {
   pool: MyPoolInfo | undefined;
 }
 
-export default function Index(): React.ReactElement {
+export default function Index (): React.ReactElement {
   const { t } = useTranslation();
   const { state } = useLocation<State>();
   const theme = useTheme();
   const { address } = useParams<{ address: string }>();
+  const onAction = useContext(ActionContext);
   const history = useHistory();
   const api = useApi(address, state?.api);
   const chain = useChain(address);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+
   const stakingConsts = useStakingConsts(address, state?.stakingConsts);
   const allValidatorsInfo = useValidators(address);
   const allValidatorsAccountIds = useMemo(() => allValidatorsInfo && allValidatorsInfo.current.concat(allValidatorsInfo.waiting)?.map((v) => v.accountId), [allValidatorsInfo]);

--- a/packages/extension-polkagate/src/popup/staking/pool/nominations/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/nominations/index.tsx
@@ -10,14 +10,14 @@ import type { MyPoolInfo, PoolStakingConsts, StakingConsts, ValidatorInfo } from
 import { faRefresh } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Divider, Grid, SxProps, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { DeriveStakingQuery } from '@polkadot/api-derive/types';
 import { BN } from '@polkadot/util';
 
-import { ActionContext, Infotip, Motion, PButton, Progress, Warning } from '../../../../components';
+import { Infotip, Motion, PButton, Progress, Warning } from '../../../../components';
 import { useApi, useChain, useFormatted, usePool, useStakingConsts, useTranslation, useUnSupportedNetwork, useValidators, useValidatorsIdentities } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
 import { STAKING_CHAINS } from '../../../../util/constants';
@@ -39,12 +39,11 @@ export default function Index (): React.ReactElement {
   const { state } = useLocation<State>();
   const theme = useTheme();
   const { address } = useParams<{ address: string }>();
-  const onAction = useContext(ActionContext);
   const history = useHistory();
   const api = useApi(address, state?.api);
   const chain = useChain(address);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
 
   const stakingConsts = useStakingConsts(address, state?.stakingConsts);
   const allValidatorsInfo = useValidators(address);

--- a/packages/extension-polkagate/src/popup/staking/pool/redeem/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/redeem/index.tsx
@@ -17,10 +17,11 @@ import keyring from '@polkadot/ui-keyring';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
 import { AccountHolderWithProxy, ActionContext, AmountFee, FormatBalance, Motion, PasswordUseProxyConfirm, Popup, WrongPasswordAlert } from '../../../../components';
-import { useAccountDisplay, useProxies, useTranslation } from '../../../../hooks';
+import { useAccountDisplay, useProxies, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
+import { STAKING_CHAINS } from '../../../../util/constants';
 import { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from '../rewards/partials/TxDetail';
@@ -37,11 +38,14 @@ interface Props {
   setRefresh: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-export default function RedeemableWithdrawReview({ address, amount, api, available, chain, formatted, setRefresh, setShow, show }: Props): React.ReactElement {
+export default function RedeemableWithdrawReview ({ address, amount, api, available, chain, formatted, setRefresh, setShow, show }: Props): React.ReactElement {
   const { t } = useTranslation();
   const proxies = useProxies(api, formatted);
   const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);
   const [selectedProxy, setSelectedProxy] = useState<Proxy | undefined>();

--- a/packages/extension-polkagate/src/popup/staking/pool/redeem/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/redeem/index.tsx
@@ -44,7 +44,7 @@ export default function RedeemableWithdrawReview ({ address, amount, api, availa
   const name = useAccountDisplay(address);
   const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
 
   const [password, setPassword] = useState<string | undefined>();
   const [isPasswordError, setIsPasswordError] = useState(false);

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/createPool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/createPool/index.tsx
@@ -6,14 +6,14 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { ApiPromise } from '@polkadot/api';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { ActionContext, AddressInput, AmountWithOptions, InputWithLabel, PButton, ShowBalance } from '../../../../../components';
+import { AddressInput, AmountWithOptions, InputWithLabel, PButton, ShowBalance } from '../../../../../components';
 import { useApi, useChain, useDecimal, useFormatted, usePoolConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../../partials';
 import { MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../../util/constants';
@@ -37,9 +37,8 @@ export default function CreatePool (): React.ReactElement {
   const history = useHistory();
   const token = useToken(address);
   const decimal = useDecimal(address);
-  const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
 
   const poolStakingConsts = usePoolConsts(address, state?.poolStakingConsts);
   const chain = useChain(address);

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/createPool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/createPool/index.tsx
@@ -6,17 +6,17 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Grid, Typography } from '@mui/material';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { ApiPromise } from '@polkadot/api';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AddressInput, AmountWithOptions, InputWithLabel, PButton, ShowBalance } from '../../../../../components';
-import { useApi, useChain, useDecimal, useFormatted, usePoolConsts, useToken, useTranslation } from '../../../../../hooks';
+import { ActionContext, AddressInput, AmountWithOptions, InputWithLabel, PButton, ShowBalance } from '../../../../../components';
+import { useApi, useChain, useDecimal, useFormatted, usePoolConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../../partials';
-import { DEFAULT_TOKEN_DECIMALS, MAX_AMOUNT_LENGTH } from '../../../../../util/constants';
+import { MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../../util/constants';
 import { PoolInfo, PoolStakingConsts } from '../../../../../util/types';
 import { amountToHuman, amountToMachine } from '../../../../../util/utils';
 import Review from './Review';
@@ -28,7 +28,7 @@ interface State {
   poolStakingConsts: PoolStakingConsts;
 }
 
-export default function CreatePool(): React.ReactElement {
+export default function CreatePool (): React.ReactElement {
   const { t } = useTranslation();
   const { address } = useParams<{ address: string }>();
   const { state } = useLocation<State>();
@@ -37,6 +37,10 @@ export default function CreatePool(): React.ReactElement {
   const history = useHistory();
   const token = useToken(address);
   const decimal = useDecimal(address);
+  const onAction = useContext(ActionContext);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+
   const poolStakingConsts = usePoolConsts(address, state?.poolStakingConsts);
   const chain = useChain(address);
 

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/index.tsx
@@ -5,13 +5,12 @@
 
 import { Grid, Typography } from '@mui/material';
 import { Circle } from 'better-react-spinkit';
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { ApiPromise } from '@polkadot/api';
 
-import { ActionContext } from '../../../../components';
 import { useApi, useBalances, useFormatted, usePool, usePoolConsts, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand } from '../../../../partials';
 import { STAKING_CHAINS } from '../../../../util/constants';
@@ -32,9 +31,8 @@ export default function Stake (): React.ReactElement {
   const formatted = useFormatted(address);
   const { state } = useLocation<State>();
   const api = useApi(address, state?.api);
-  const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
 
   const poolStakingConsts = usePoolConsts(address, state?.consts);
   const balances = useBalances(address);

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/index.tsx
@@ -5,14 +5,16 @@
 
 import { Grid, Typography } from '@mui/material';
 import { Circle } from 'better-react-spinkit';
-import React, { useCallback } from 'react';
+import React, { useCallback, useContext } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { ApiPromise } from '@polkadot/api';
 
-import { useApi, useBalances, useFormatted, usePool, usePoolConsts, useTranslation } from '../../../../hooks';
+import { ActionContext } from '../../../../components';
+import { useApi, useBalances, useFormatted, usePool, usePoolConsts, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand } from '../../../../partials';
+import { STAKING_CHAINS } from '../../../../util/constants';
 import { MyPoolInfo, PoolStakingConsts } from '../../../../util/types';
 import BondExtra from './bondExtra';
 import StakeInitialChoice from './StakeInitialChoice';
@@ -24,12 +26,16 @@ interface State {
   pathname: string;
 }
 
-export default function Stake(): React.ReactElement {
+export default function Stake (): React.ReactElement {
   const { t } = useTranslation();
   const { address } = useParams<{ address: string }>();
   const formatted = useFormatted(address);
   const { state } = useLocation<State>();
   const api = useApi(address, state?.api);
+  const onAction = useContext(ActionContext);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+
   const poolStakingConsts = usePoolConsts(address, state?.consts);
   const balances = useBalances(address);
   const pool = usePool(address);

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/joinPool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/joinPool/index.tsx
@@ -6,17 +6,17 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Grid, Typography } from '@mui/material';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { ApiPromise } from '@polkadot/api';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AmountWithOptions, PButton, ShowBalance } from '../../../../../components';
-import { useApi, useDecimal, useFormatted, usePoolConsts, usePools, useToken, useTranslation } from '../../../../../hooks';
+import { ActionContext, AmountWithOptions, PButton, ShowBalance } from '../../../../../components';
+import { useApi, useDecimal, useFormatted, usePoolConsts, usePools, useToken, useTranslation, useUnSupportedNetwork } from '../../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../../partials';
-import { MAX_AMOUNT_LENGTH, PREFERRED_POOL_NAME } from '../../../../../util/constants';
+import { MAX_AMOUNT_LENGTH, PREFERRED_POOL_NAME, STAKING_CHAINS } from '../../../../../util/constants';
 import { PoolInfo, PoolStakingConsts } from '../../../../../util/types';
 import { amountToHuman, amountToMachine } from '../../../../../util/utils';
 import PoolsTable from './partials/PoolsTable';
@@ -28,13 +28,17 @@ interface State {
   poolStakingConsts: PoolStakingConsts;
 }
 
-export default function JoinPool(): React.ReactElement {
+export default function JoinPool (): React.ReactElement {
   const { t } = useTranslation();
 
   const { address } = useParams<{ address: string }>();
   const { state } = useLocation<State>();
   const formatted = useFormatted(address);
   const api = useApi(address, state?.api);
+  const onAction = useContext(ActionContext);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+
   const poolStakingConsts = usePoolConsts(address, state?.poolStakingConsts);
   const history = useHistory();
 

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/joinPool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/joinPool/index.tsx
@@ -6,14 +6,14 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { Grid, Typography } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { ApiPromise } from '@polkadot/api';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { ActionContext, AmountWithOptions, PButton, ShowBalance } from '../../../../../components';
+import { AmountWithOptions, PButton, ShowBalance } from '../../../../../components';
 import { useApi, useDecimal, useFormatted, usePoolConsts, usePools, useToken, useTranslation, useUnSupportedNetwork } from '../../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../../partials';
 import { MAX_AMOUNT_LENGTH, PREFERRED_POOL_NAME, STAKING_CHAINS } from '../../../../../util/constants';
@@ -35,9 +35,8 @@ export default function JoinPool (): React.ReactElement {
   const { state } = useLocation<State>();
   const formatted = useFormatted(address);
   const api = useApi(address, state?.api);
-  const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
 
   const poolStakingConsts = usePoolConsts(address, state?.poolStakingConsts);
   const history = useHistory();

--- a/packages/extension-polkagate/src/popup/staking/pool/unstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/unstake/index.tsx
@@ -12,16 +12,16 @@ import { faPersonCircleXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { AutoDelete as AutoDeleteIcon } from '@mui/icons-material';
 import { Button, Grid, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
-import { useApi, useChain, useDecimal, useFormatted, usePool, usePoolConsts, useStakingConsts, useToken, useTranslation } from '../../../../hooks';
+import { ActionContext, AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
+import { useApi, useChain, useDecimal, useFormatted, usePool, usePoolConsts, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
-import { DATE_OPTIONS, DEFAULT_TOKEN_DECIMALS, FLOATING_POINT_DIGIT, MAX_AMOUNT_LENGTH } from '../../../../util/constants';
+import { DATE_OPTIONS, DEFAULT_TOKEN_DECIMALS, MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../util/constants';
 import { amountToHuman, amountToMachine } from '../../../../util/utils';
 import Asset from '../../../send/partial/Asset';
 import ShowPool from '../../partial/ShowPool';
@@ -40,9 +40,9 @@ interface State {
 const CONDITION_MAP = {
   DESTROY: 1,
   REMOVE_ALL: 2
-}
+};
 
-export default function Index(): React.ReactElement {
+export default function Index (): React.ReactElement {
   const { t } = useTranslation();
   const { state } = useLocation<State>();
   const theme = useTheme();
@@ -50,6 +50,10 @@ export default function Index(): React.ReactElement {
   const history = useHistory();
   const api = useApi(address, state?.api);
   const chain = useChain(address);
+  const onAction = useContext(ActionContext);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+
   const [refresh, setRefresh] = useState<boolean>(false);
   const myPool = usePool(address, undefined, refresh);
   const formatted = useFormatted(address);
@@ -380,7 +384,6 @@ export default function Index(): React.ReactElement {
       {goChange && helperButton === 2 && myPool && formatted &&
         <RemoveAll
           address={address}
-          api={api}
           pool={myPool}
           setRefresh={setRefresh}
           setShowRemoveAll={setGoChange}

--- a/packages/extension-polkagate/src/popup/staking/pool/unstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/unstake/index.tsx
@@ -12,13 +12,13 @@ import { faPersonCircleXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { AutoDelete as AutoDeleteIcon } from '@mui/icons-material';
 import { Button, Grid, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { ActionContext, AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
+import { AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
 import { useApi, useChain, useDecimal, useFormatted, usePool, usePoolConsts, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
 import { DATE_OPTIONS, DEFAULT_TOKEN_DECIMALS, MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../util/constants';
@@ -50,9 +50,8 @@ export default function Index (): React.ReactElement {
   const history = useHistory();
   const api = useApi(address, state?.api);
   const chain = useChain(address);
-  const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
 
   const [refresh, setRefresh] = useState<boolean>(false);
   const myPool = usePool(address, undefined, refresh);

--- a/packages/extension-polkagate/src/popup/staking/solo/fastUnstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/fastUnstake/index.tsx
@@ -10,15 +10,16 @@ import type { AccountStakingInfo, StakingConsts } from '../../../../util/types';
 import CheckCircleOutlineSharpIcon from '@mui/icons-material/CheckCircleOutlineSharp';
 import { Grid, Typography, useTheme } from '@mui/material';
 import { Circle } from 'better-react-spinkit';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN, BN_ONE } from '@polkadot/util';
 
-import { Motion, PButton, Warning } from '../../../../components';
-import { useApi, useBalances, useChain, useDecimal, useFormatted, useIsExposed, useStakingAccount, useStakingConsts, useToken, useTranslation } from '../../../../hooks';
+import { ActionContext, Motion, PButton, Warning } from '../../../../components';
+import { useApi, useBalances, useChain, useDecimal, useFormatted, useIsExposed, useStakingAccount, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
+import { STAKING_CHAINS } from '../../../../util/constants';
 import { amountToHuman } from '../../../../util/utils';
 import { getValue } from '../../../account/util';
 import FastUnstakeReview from './Review';
@@ -30,7 +31,7 @@ interface State {
   stakingAccount: AccountStakingInfo | undefined
 }
 
-export default function Index(): React.ReactElement {
+export default function Index (): React.ReactElement {
   const { t } = useTranslation();
   const { state } = useLocation<State>();
   const theme = useTheme();
@@ -40,6 +41,10 @@ export default function Index(): React.ReactElement {
   const chain = useChain(address);
   const formatted = useFormatted(address);
   const token = useToken(address);
+  const onAction = useContext(ActionContext);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+
   const stakingAccount = useStakingAccount(formatted, state?.stakingAccount);
   const myBalances = useBalances(address);
   const mayBeMyStashBalances = useBalances(stakingAccount?.stashId);

--- a/packages/extension-polkagate/src/popup/staking/solo/fastUnstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/fastUnstake/index.tsx
@@ -10,13 +10,13 @@ import type { AccountStakingInfo, StakingConsts } from '../../../../util/types';
 import CheckCircleOutlineSharpIcon from '@mui/icons-material/CheckCircleOutlineSharp';
 import { Grid, Typography, useTheme } from '@mui/material';
 import { Circle } from 'better-react-spinkit';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN, BN_ONE } from '@polkadot/util';
 
-import { ActionContext, Motion, PButton, Warning } from '../../../../components';
+import { Motion, PButton, Warning } from '../../../../components';
 import { useApi, useBalances, useChain, useDecimal, useFormatted, useIsExposed, useStakingAccount, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
 import { STAKING_CHAINS } from '../../../../util/constants';
@@ -41,9 +41,8 @@ export default function Index (): React.ReactElement {
   const chain = useChain(address);
   const formatted = useFormatted(address);
   const token = useToken(address);
-  const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
 
   const stakingAccount = useStakingAccount(formatted, state?.stakingAccount);
   const myBalances = useBalances(address);

--- a/packages/extension-polkagate/src/popup/staking/solo/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/index.tsx
@@ -18,10 +18,10 @@ import { BN, BN_ZERO } from '@polkadot/util';
 
 import { controllerSettingBlack, controllerSettingWhite, soloSettingBlack, soloSettingWhite, stashSettingBlack, stashSettingWhite } from '../../../assets/icons';
 import { ActionContext, FormatBalance, HorizontalMenuItem, Identicon, ShowBalance } from '../../../components';
-import { useApi, useBalances, useChain, useChainName, useDecimal, useFormatted, useMinToReceiveRewardsInSolo, useMyAccountIdentity, useStakingAccount, useStakingConsts, useStakingRewardDestinationAddress, useStakingRewards, useToken, useTranslation } from '../../../hooks';
+import { useApi, useBalances, useChain, useChainName, useDecimal, useFormatted, useMinToReceiveRewardsInSolo, useMyAccountIdentity, useStakingAccount, useStakingConsts, useStakingRewardDestinationAddress, useStakingRewards, useToken, useTranslation, useUnSupportedNetwork } from '../../../hooks';
 import { ChainSwitch, HeaderBrand } from '../../../partials';
 import BouncingSubTitle from '../../../partials/BouncingSubTitle';
-import { BALANCES_VALIDITY_PERIOD, DATE_OPTIONS, TIME_TO_SHAKE_ICON } from '../../../util/constants';
+import { BALANCES_VALIDITY_PERIOD, DATE_OPTIONS, STAKING_CHAINS, TIME_TO_SHAKE_ICON } from '../../../util/constants';
 import AccountBrief from '../../account/AccountBrief';
 import { getValue } from '../../account/util';
 import RewardsDetail from './rewards/RewardsDetail';
@@ -42,7 +42,7 @@ interface State {
 
 const noop = () => null;
 
-export default function Index(): React.ReactElement {
+export default function Index (): React.ReactElement {
   const { t } = useTranslation();
   const onAction = useContext(ActionContext);
   const theme = useTheme();
@@ -50,6 +50,9 @@ export default function Index(): React.ReactElement {
   const { pathname, state } = useLocation<State>();
   const { address } = useParams<{ address: string }>();
   const formatted = useFormatted(address);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+
   const [refresh, setRefresh] = useState<boolean>(false);
   const stakingAccount = useStakingAccount(address, state?.stakingAccount, refresh, setRefresh);
   const rewardDestinationAddress = useStakingRewardDestinationAddress(stakingAccount);

--- a/packages/extension-polkagate/src/popup/staking/solo/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/index.tsx
@@ -51,7 +51,7 @@ export default function Index (): React.ReactElement {
   const { address } = useParams<{ address: string }>();
   const formatted = useFormatted(address);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
 
   const [refresh, setRefresh] = useState<boolean>(false);
   const stakingAccount = useStakingAccount(address, state?.stakingAccount, refresh, setRefresh);

--- a/packages/extension-polkagate/src/popup/staking/solo/nominations/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/nominations/index.tsx
@@ -10,16 +10,17 @@ import type { AccountStakingInfo, StakingConsts, ValidatorInfo } from '../../../
 import { faRefresh } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Divider, Grid, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { DeriveStakingQuery } from '@polkadot/api-derive/types';
 import { BN_ZERO } from '@polkadot/util';
 
-import { Infotip, Motion, PButton, Progress, Warning } from '../../../../components';
-import { useApi, useChain, useFormatted, useStakingAccount, useStakingConsts, useTranslation, useValidators, useValidatorsIdentities } from '../../../../hooks';
+import { ActionContext, Infotip, Motion, PButton, Progress, Warning } from '../../../../components';
+import { useApi, useChain, useFormatted, useStakingAccount, useStakingConsts, useTranslation, useUnSupportedNetwork, useValidators, useValidatorsIdentities } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
+import { STAKING_CHAINS } from '../../../../util/constants';
 import SelectValidators from '../../partial/SelectValidators';
 import Review from '../../partial/SelectValidatorsReview';
 import ValidatorsTable from '../../partial/ValidatorsTable';
@@ -32,7 +33,7 @@ interface State {
   stakingAccount: AccountStakingInfo | undefined
 }
 
-export default function Index(): React.ReactElement {
+export default function Index (): React.ReactElement {
   const { t } = useTranslation();
   const { state } = useLocation<State>();
   const theme = useTheme();
@@ -40,6 +41,9 @@ export default function Index(): React.ReactElement {
   const history = useHistory();
   const api = useApi(address, state?.api);
   const chain = useChain(address);
+  const onAction = useContext(ActionContext);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
   const stakingConsts = useStakingConsts(address, state?.stakingConsts);
 
   const allValidatorsInfo = useValidators(address);

--- a/packages/extension-polkagate/src/popup/staking/solo/nominations/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/nominations/index.tsx
@@ -10,14 +10,14 @@ import type { AccountStakingInfo, StakingConsts, ValidatorInfo } from '../../../
 import { faRefresh } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Divider, Grid, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { DeriveStakingQuery } from '@polkadot/api-derive/types';
 import { BN_ZERO } from '@polkadot/util';
 
-import { ActionContext, Infotip, Motion, PButton, Progress, Warning } from '../../../../components';
+import { Infotip, Motion, PButton, Progress, Warning } from '../../../../components';
 import { useApi, useChain, useFormatted, useStakingAccount, useStakingConsts, useTranslation, useUnSupportedNetwork, useValidators, useValidatorsIdentities } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
 import { STAKING_CHAINS } from '../../../../util/constants';
@@ -41,9 +41,8 @@ export default function Index (): React.ReactElement {
   const history = useHistory();
   const api = useApi(address, state?.api);
   const chain = useChain(address);
-  const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
   const stakingConsts = useStakingConsts(address, state?.stakingConsts);
 
   const allValidatorsInfo = useValidators(address);

--- a/packages/extension-polkagate/src/popup/staking/solo/restake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/restake/index.tsx
@@ -8,16 +8,16 @@ import type { Balance } from '@polkadot/types/interfaces';
 import type { AccountStakingInfo, StakingConsts } from '../../../../util/types';
 
 import { Grid, useTheme } from '@mui/material';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
-import { useApi, useChain, useDecimal, useFormatted, useStakingAccount, useStakingConsts, useToken, useTranslation } from '../../../../hooks';
+import { ActionContext, AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
+import { useApi, useChain, useDecimal, useFormatted, useStakingAccount, useToken, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
-import { DEFAULT_TOKEN_DECIMALS, MAX_AMOUNT_LENGTH } from '../../../../util/constants';
+import { MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../util/constants';
 import { amountToHuman, amountToMachine } from '../../../../util/utils';
 import Asset from '../../../send/partial/Asset';
 import Review from './Review';
@@ -30,7 +30,7 @@ interface State {
   unlockingAmount: BN | undefined;
 }
 
-export default function Index(): React.ReactElement {
+export default function Index (): React.ReactElement {
   const { t } = useTranslation();
   const { state } = useLocation<State>();
   const theme = useTheme();
@@ -40,6 +40,9 @@ export default function Index(): React.ReactElement {
   const decimal = useDecimal(address);
   const formatted = useFormatted(address);
   const history = useHistory();
+  const onAction = useContext(ActionContext);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
   const stakingAccount = useStakingAccount(formatted, state?.stakingAccount);
   const token = useToken(address);
 

--- a/packages/extension-polkagate/src/popup/staking/solo/restake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/restake/index.tsx
@@ -8,13 +8,13 @@ import type { Balance } from '@polkadot/types/interfaces';
 import type { AccountStakingInfo, StakingConsts } from '../../../../util/types';
 
 import { Grid, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { ActionContext, AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
+import { AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
 import { useApi, useChain, useDecimal, useFormatted, useStakingAccount, useToken, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
 import { MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../util/constants';
@@ -40,9 +40,8 @@ export default function Index (): React.ReactElement {
   const decimal = useDecimal(address);
   const formatted = useFormatted(address);
   const history = useHistory();
-  const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
   const stakingAccount = useStakingAccount(formatted, state?.stakingAccount);
   const token = useToken(address);
 

--- a/packages/extension-polkagate/src/popup/staking/solo/stake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/stake/index.tsx
@@ -8,16 +8,16 @@ import type { Balance } from '@polkadot/types/interfaces';
 import type { AccountStakingInfo, SoloSettings, StakingConsts, ValidatorInfo } from '../../../../util/types';
 
 import { FormControl, FormControlLabel, FormLabel, Grid, Radio, RadioGroup, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
-import { useApi, useBalances, useChain, useDecimal, useFormatted, useStakingAccount, useStakingConsts, useToken, useTranslation, useValidatorSuggestion } from '../../../../hooks';
+import { ActionContext, AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
+import { useApi, useBalances, useChain, useDecimal, useFormatted, useStakingAccount, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork, useValidatorSuggestion } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
-import { MAX_AMOUNT_LENGTH } from '../../../../util/constants';
+import { MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../util/constants';
 import { amountToHuman, amountToMachine } from '../../../../util/utils';
 import Asset from '../../../send/partial/Asset';
 import SelectValidators from '../../partial/SelectValidators';
@@ -31,7 +31,7 @@ interface State {
   stakingAccount: AccountStakingInfo | undefined
 }
 
-export default function Index(): React.ReactElement {
+export default function Index (): React.ReactElement {
   const { t } = useTranslation();
   const { state } = useLocation<State>();
   const theme = useTheme();
@@ -43,9 +43,13 @@ export default function Index(): React.ReactElement {
   const chain = useChain(address);
   const formatted = useFormatted(address);
   const balances = useBalances(address);
+  const onAction = useContext(ActionContext);
+
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
   const stakingAccount = useStakingAccount(formatted, state?.stakingAccount);
   const stakingConsts = useStakingConsts(address, state?.stakingConsts);
   const autoSelectedValidators = useValidatorSuggestion(address);
+
   const [estimatedFee, setEstimatedFee] = useState<Balance | undefined>();
   const [amount, setAmount] = useState<string>();
   const [alert, setAlert] = useState<string | undefined>();

--- a/packages/extension-polkagate/src/popup/staking/solo/stake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/stake/index.tsx
@@ -8,13 +8,13 @@ import type { Balance } from '@polkadot/types/interfaces';
 import type { AccountStakingInfo, SoloSettings, StakingConsts, ValidatorInfo } from '../../../../util/types';
 
 import { FormControl, FormControlLabel, FormLabel, Grid, Radio, RadioGroup, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { ActionContext, AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
+import { AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
 import { useApi, useBalances, useChain, useDecimal, useFormatted, useStakingAccount, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork, useValidatorSuggestion } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
 import { MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../util/constants';
@@ -43,9 +43,8 @@ export default function Index (): React.ReactElement {
   const chain = useChain(address);
   const formatted = useFormatted(address);
   const balances = useBalances(address);
-  const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
   const stakingAccount = useStakingAccount(formatted, state?.stakingAccount);
   const stakingConsts = useStakingConsts(address, state?.stakingConsts);
   const autoSelectedValidators = useValidatorSuggestion(address);

--- a/packages/extension-polkagate/src/popup/staking/solo/tuneUp/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/tuneUp/index.tsx
@@ -40,7 +40,7 @@ export default function TuneUp (): React.ReactElement {
   const formatted = useFormatted(address);
   const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
   const subscanLink = (address: string) => `https://${chainName}.subscan.io/account/${String(address)}?tab=reward`;
 
   const putInFrontInfo = useNeedsPutInFrontOf(address);

--- a/packages/extension-polkagate/src/popup/staking/solo/tuneUp/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/tuneUp/index.tsx
@@ -20,16 +20,17 @@ import keyring from '@polkadot/ui-keyring';
 import { BN_ONE } from '@polkadot/util';
 
 import { ActionContext, Motion, PasswordUseProxyConfirm, Progress, ShortAddress, WrongPasswordAlert } from '../../../../components';
-import { useAccountDisplay, useApi, useChain, useChainName, useFormatted, useNeedsPutInFrontOf, useNeedsRebag, useProxies, useTranslation } from '../../../../hooks';
+import { useAccountDisplay, useApi, useChain, useChainName, useFormatted, useNeedsPutInFrontOf, useNeedsRebag, useProxies, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
+import { STAKING_CHAINS } from '../../../../util/constants';
 import getLogo from '../../../../util/getLogo';
 import { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './TxDetail';
 
-export default function TuneUp(): React.ReactElement {
+export default function TuneUp (): React.ReactElement {
   const { t } = useTranslation();
   const { state } = useLocation<State>();
   const { address } = useParams<{ address: string }>();
@@ -39,6 +40,7 @@ export default function TuneUp(): React.ReactElement {
   const formatted = useFormatted(address);
   const onAction = useContext(ActionContext);
 
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
   const subscanLink = (address: string) => `https://${chainName}.subscan.io/account/${String(address)}?tab=reward`;
 
   const putInFrontInfo = useNeedsPutInFrontOf(address);

--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
@@ -8,16 +8,16 @@ import type { Balance } from '@polkadot/types/interfaces';
 import type { AccountStakingInfo, StakingConsts } from '../../../../util/types';
 
 import { Grid, useTheme } from '@mui/material';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
-import { useApi, useChain, useDecimal, useFormatted, useStakingAccount, useStakingConsts, useToken, useTranslation } from '../../../../hooks';
+import { ActionContext, AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
+import { useApi, useChain, useDecimal, useFormatted, useStakingAccount, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
-import { DATE_OPTIONS, MAX_AMOUNT_LENGTH } from '../../../../util/constants';
+import { DATE_OPTIONS, MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../util/constants';
 import { amountToHuman, amountToMachine } from '../../../../util/utils';
 import Asset from '../../../send/partial/Asset';
 import Review from './Review';
@@ -40,7 +40,9 @@ export default function Index(): React.ReactElement {
   const formatted = useFormatted(address);
   const token = useToken(address);
   const decimal = useDecimal(address);
+  const onAction = useContext(ActionContext);
 
+  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
   const stakingAccount = useStakingAccount(formatted, state?.stakingAccount);
   const stakingConsts = useStakingConsts(address, state?.stakingConsts);
   const [estimatedFee, setEstimatedFee] = useState<Balance | undefined>();

--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
@@ -8,13 +8,13 @@ import type { Balance } from '@polkadot/types/interfaces';
 import type { AccountStakingInfo, StakingConsts } from '../../../../util/types';
 
 import { Grid, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { ActionContext, AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
+import { AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
 import { useApi, useChain, useDecimal, useFormatted, useStakingAccount, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
 import { DATE_OPTIONS, MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../util/constants';
@@ -40,9 +40,8 @@ export default function Index(): React.ReactElement {
   const formatted = useFormatted(address);
   const token = useToken(address);
   const decimal = useDecimal(address);
-  const onAction = useContext(ActionContext);
 
-  useUnSupportedNetwork(address, STAKING_CHAINS, () => onAction('/'));
+  useUnSupportedNetwork(address, STAKING_CHAINS);
   const stakingAccount = useStakingAccount(formatted, state?.stakingAccount);
   const stakingConsts = useStakingConsts(address, state?.stakingConsts);
   const [estimatedFee, setEstimatedFee] = useState<Balance | undefined>();


### PR DESCRIPTION
## Works done

- [x] Create `useUnSupportedNetwork.ts`
- [x] Fix staking option issue
- [x] Enhancing Solo and Pool staking pages with `useUnSupportedNetwork.ts`
- [x] Fix some small bugs

This PR is going to address issue #873 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Feature: Introduced a new functionality to check for unsupported networks. This feature enhances the user experience by preventing operations on unsupported networks, thereby reducing potential errors.
- Improvement: Updated the Staking Options component to control its own visibility. This change improves the user interface's intuitiveness, making it easier for users to navigate through staking options.
- Refactor: Reorganized import statements and added new hooks across various components for better code readability and maintainability. This change is not directly visible to end-users but contributes to the overall software quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->