### PR TITLE
fix unstakeAll issue

### DIFF
--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/Review.tsx
@@ -100,7 +100,7 @@ export default function Review({ address, amount, chilled, estimatedFee, hasNomi
 
       if (unlockingLen >= maxUnlockingChunks) {
         const optSpans = await api.query.staking.slashingSpans(formatted);
-        const spanCount = optSpans.isNone ? 0 : optSpans.unwrap().prior.length + 1;
+        const spanCount = optSpans.isNone ? 0 : optSpans.unwrap().prior.length + 1 as number;
 
         txs.push(redeem(spanCount));
       }
@@ -135,7 +135,7 @@ export default function Review({ address, amount, chilled, estimatedFee, hasNomi
       setShowWaitScreen(false);
       setShowConfirmation(true);
     } catch (e) {
-      console.log('error:', e);
+      console.error('Unstaking error:', e);
       setIsPasswordError(true);
     }
   }, [amount, api, chain, chilled, decimal, estimatedFee, formatted, hasNominator, maxUnlockingChunks, name, password, redeem, selectedProxy, selectedProxyAddress, selectedProxyName, unbonded, unlockingLen, isUnstakeAll]);

--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/Review.tsx
@@ -24,7 +24,7 @@ import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
 import { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
-import { amountToMachine, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
+import { amountToHuman, amountToMachine, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './partials/TxDetail';
 
 interface Props {
@@ -37,6 +37,7 @@ interface Props {
   redeem: SubmittableExtrinsicFunction<'promise', AnyTuple> | undefined;
   redeemDate: string | undefined;
   setShow: React.Dispatch<React.SetStateAction<boolean>>;
+  staked: BN;
   show: boolean;
   total: BN | undefined;
   unlockingLen: number;
@@ -44,7 +45,7 @@ interface Props {
   isUnstakeAll: boolean;
 }
 
-export default function Review({ address, amount, chilled, estimatedFee, hasNominator, maxUnlockingChunks, redeem, redeemDate, setShow, show, total, unbonded, unlockingLen, isUnstakeAll }: Props): React.ReactElement {
+export default function Review({ address, amount, chilled, estimatedFee, hasNominator, isUnstakeAll, maxUnlockingChunks, redeem, redeemDate, setShow, show, staked, total, unbonded, unlockingLen }: Props): React.ReactElement {
   const { t } = useTranslation();
   const formatted = useFormatted(address);
   const chain = useChain(address);
@@ -105,7 +106,7 @@ export default function Review({ address, amount, chilled, estimatedFee, hasNomi
         txs.push(redeem(spanCount));
       }
 
-      if (isUnstakeAll && hasNominator) {
+      if ((isUnstakeAll || amount === amountToHuman(staked, decimal)) && hasNominator) {
         txs.push(chilled());
       }
 
@@ -138,7 +139,7 @@ export default function Review({ address, amount, chilled, estimatedFee, hasNomi
       console.error('Unstaking error:', e);
       setIsPasswordError(true);
     }
-  }, [amount, api, chain, chilled, decimal, estimatedFee, formatted, hasNominator, maxUnlockingChunks, name, password, redeem, selectedProxy, selectedProxyAddress, selectedProxyName, unbonded, unlockingLen, isUnstakeAll]);
+  }, [amount, api, chain, chilled, decimal, estimatedFee, formatted, hasNominator, maxUnlockingChunks, name, password, redeem, selectedProxy, selectedProxyAddress, selectedProxyName, staked, unbonded, unlockingLen, isUnstakeAll]);
 
   const _onBackClick = useCallback(() => {
     setShow(false);

--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/Review.tsx
@@ -41,10 +41,10 @@ interface Props {
   total: BN | undefined;
   unlockingLen: number;
   unbonded: SubmittableExtrinsicFunction<'promise', AnyTuple> | undefined;
-  unstakeAllAmount: boolean;
+  isUnstakeAll: boolean;
 }
 
-export default function Review({ address, amount, chilled, estimatedFee, hasNominator, maxUnlockingChunks, redeem, redeemDate, setShow, show, total, unbonded, unlockingLen, unstakeAllAmount }: Props): React.ReactElement {
+export default function Review({ address, amount, chilled, estimatedFee, hasNominator, maxUnlockingChunks, redeem, redeemDate, setShow, show, total, unbonded, unlockingLen, isUnstakeAll }: Props): React.ReactElement {
   const { t } = useTranslation();
   const formatted = useFormatted(address);
   const chain = useChain(address);
@@ -105,7 +105,7 @@ export default function Review({ address, amount, chilled, estimatedFee, hasNomi
         txs.push(redeem(spanCount));
       }
 
-      if (unstakeAllAmount && hasNominator) {
+      if (isUnstakeAll && hasNominator) {
         txs.push(chilled());
       }
 
@@ -138,7 +138,7 @@ export default function Review({ address, amount, chilled, estimatedFee, hasNomi
       console.log('error:', e);
       setIsPasswordError(true);
     }
-  }, [amount, api, chain, chilled, decimal, estimatedFee, formatted, hasNominator, maxUnlockingChunks, name, password, redeem, selectedProxy, selectedProxyAddress, selectedProxyName, unbonded, unlockingLen, unstakeAllAmount]);
+  }, [amount, api, chain, chilled, decimal, estimatedFee, formatted, hasNominator, maxUnlockingChunks, name, password, redeem, selectedProxy, selectedProxyAddress, selectedProxyName, unbonded, unlockingLen, isUnstakeAll]);
 
   const _onBackClick = useCallback(() => {
     setShow(false);

--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
@@ -222,6 +222,7 @@ export default function Index(): React.ReactElement {
           chilled={chilled}
           estimatedFee={estimatedFee}
           hasNominator={!!stakingAccount?.nominators?.length}
+          isUnstakeAll={isUnstakeAll}
           maxUnlockingChunks={maxUnlockingChunks}
           redeem={redeem}
           redeemDate={redeemDate}
@@ -230,7 +231,6 @@ export default function Index(): React.ReactElement {
           total={totalAfterUnstake}
           unbonded={unbonded}
           unlockingLen={unlockingLen ?? 0}
-          isUnstakeAll={isUnstakeAll}
         />
       }
     </Motion>

--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
@@ -17,9 +17,9 @@ import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 import { AmountWithOptions, Motion, PButton, Warning } from '../../../../components';
 import { useApi, useChain, useDecimal, useFormatted, useStakingAccount, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../../hooks';
 import { HeaderBrand, SubTitle } from '../../../../partials';
+import Asset from '../../../../partials/Asset';
 import { DATE_OPTIONS, MAX_AMOUNT_LENGTH, STAKING_CHAINS } from '../../../../util/constants';
 import { amountToHuman, amountToMachine } from '../../../../util/utils';
-import Asset from '../../../../partials/Asset';
 import Review from './Review';
 
 interface State {
@@ -50,8 +50,8 @@ export default function Index(): React.ReactElement {
   const [showReview, setShowReview] = useState<boolean>(false);
   const [unstakeAllAmount, setUnstakeAllAmount] = useState<boolean>(false);
 
-  const staked = useMemo(() => stakingAccount && stakingAccount.stakingLedger.active, [stakingAccount]);
-  const totalAfterUnstake = useMemo(() => staked && decimal && staked.sub(amountToMachine(amount, decimal)) as BN | undefined, [amount, decimal, staked]);
+  const staked = useMemo(() => stakingAccount && stakingAccount.stakingLedger.active as unknown as BN, [stakingAccount]);
+  const totalAfterUnstake = useMemo(() => staked && decimal ? staked.sub(amountToMachine(amount, decimal)) : undefined, [amount, decimal, staked]);
   const unlockingLen = stakingAccount?.stakingLedger?.unlocking?.length;
   const maxUnlockingChunks = api && api.consts.staking.maxUnlockingChunks?.toNumber() as unknown as number;
   const amountAsBN = useMemo(() => amountToMachine(amount, decimal), [amount, decimal]);
@@ -104,7 +104,7 @@ export default function Index(): React.ReactElement {
         txs.push(redeem(...dummyParams));
       }
 
-      if (amountAsBN.eq(staked)) {
+      if (unstakeAllAmount) {
         txs.push(chilled());
       }
 
@@ -114,7 +114,7 @@ export default function Index(): React.ReactElement {
 
       setEstimatedFee(api?.createType('Balance', partialFee));
     }
-  }, [amountAsBN, api, chilled, formatted, maxUnlockingChunks, redeem, staked, unbonded, unlockingLen]);
+  }, [amountAsBN, api, chilled, formatted, maxUnlockingChunks, redeem, staked, unbonded, unlockingLen, unstakeAllAmount]);
 
   useEffect(() => {
     if (amountAsBN && redeem && chilled && maxUnlockingChunks && unlockingLen !== undefined && unbonded && formatted && staked) {
@@ -219,21 +219,18 @@ export default function Index(): React.ReactElement {
         <Review
           address={address}
           amount={amount}
-          api={api}
-          chain={chain}
           chilled={chilled}
           estimatedFee={estimatedFee}
-          formatted={formatted}
           hasNominator={!!stakingAccount?.nominators?.length}
           maxUnlockingChunks={maxUnlockingChunks}
           redeem={redeem}
           redeemDate={redeemDate}
           setShow={setShowReview}
           show={showReview}
-          staked={staked}
           total={totalAfterUnstake}
           unbonded={unbonded}
           unlockingLen={unlockingLen ?? 0}
+          unstakeAllAmount={unstakeAllAmount}
         />
       }
     </Motion>

--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
@@ -138,7 +138,9 @@ export default function Index(): React.ReactElement {
       return;
     }
 
-    setAmount(value.slice(0, MAX_AMOUNT_LENGTH));
+    const roundedAmount = value.slice(0, MAX_AMOUNT_LENGTH);
+
+    setAmount(roundedAmount);
   }, [decimal]);
 
   const onAllAmount = useCallback(() => {
@@ -219,6 +221,7 @@ export default function Index(): React.ReactElement {
         <Review
           address={address}
           amount={amount}
+          staked={staked}
           chilled={chilled}
           estimatedFee={estimatedFee}
           hasNominator={!!stakingAccount?.nominators?.length}

--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/index.tsx
@@ -48,7 +48,7 @@ export default function Index(): React.ReactElement {
   const [amount, setAmount] = useState<string>();
   const [alert, setAlert] = useState<string | undefined>();
   const [showReview, setShowReview] = useState<boolean>(false);
-  const [unstakeAllAmount, setUnstakeAllAmount] = useState<boolean>(false);
+  const [isUnstakeAll, setIsUnstakeAll] = useState<boolean>(false);
 
   const staked = useMemo(() => stakingAccount && stakingAccount.stakingLedger.active as unknown as BN, [stakingAccount]);
   const totalAfterUnstake = useMemo(() => staked && decimal ? staked.sub(amountToMachine(amount, decimal)) : undefined, [amount, decimal, staked]);
@@ -78,7 +78,7 @@ export default function Index(): React.ReactElement {
       return setAlert(t('It is more than already staked.'));
     }
 
-    if (api && staked && stakingConsts && !staked.sub(amountAsBN).isZero() && !unstakeAllAmount && staked.sub(amountAsBN).lt(stakingConsts.minNominatorBond)) {
+    if (api && staked && stakingConsts && !staked.sub(amountAsBN).isZero() && !isUnstakeAll && staked.sub(amountAsBN).lt(stakingConsts.minNominatorBond)) {
       const remained = api.createType('Balance', staked.sub(amountAsBN)).toHuman();
       const min = api.createType('Balance', stakingConsts.minNominatorBond).toHuman();
 
@@ -86,7 +86,7 @@ export default function Index(): React.ReactElement {
     }
 
     setAlert(undefined);
-  }, [amountAsBN, api, staked, stakingConsts, t, unstakeAllAmount]);
+  }, [amountAsBN, api, staked, stakingConsts, t, isUnstakeAll]);
 
   const getFee = useCallback(async () => {
     const txs = [];
@@ -104,7 +104,7 @@ export default function Index(): React.ReactElement {
         txs.push(redeem(...dummyParams));
       }
 
-      if (unstakeAllAmount) {
+      if (isUnstakeAll) {
         txs.push(chilled());
       }
 
@@ -114,7 +114,7 @@ export default function Index(): React.ReactElement {
 
       setEstimatedFee(api?.createType('Balance', partialFee));
     }
-  }, [amountAsBN, api, chilled, formatted, maxUnlockingChunks, redeem, staked, unbonded, unlockingLen, unstakeAllAmount]);
+  }, [amountAsBN, api, chilled, formatted, maxUnlockingChunks, redeem, staked, unbonded, unlockingLen, isUnstakeAll]);
 
   useEffect(() => {
     if (amountAsBN && redeem && chilled && maxUnlockingChunks && unlockingLen !== undefined && unbonded && formatted && staked) {
@@ -130,7 +130,7 @@ export default function Index(): React.ReactElement {
   }, [address, history, state]);
 
   const onChangeAmount = useCallback((value: string) => {
-    setUnstakeAllAmount(false);
+    setIsUnstakeAll(false);
 
     if (decimal && value.length > decimal - 1) {
       console.log(`The amount digits is more than decimal:${decimal}`);
@@ -148,7 +148,7 @@ export default function Index(): React.ReactElement {
 
     const allToShow = amountToHuman(staked.toString(), decimal);
 
-    setUnstakeAllAmount(true);
+    setIsUnstakeAll(true);
     setAmount(allToShow);
   }, [decimal, staked]);
 
@@ -230,7 +230,7 @@ export default function Index(): React.ReactElement {
           total={totalAfterUnstake}
           unbonded={unbonded}
           unlockingLen={unlockingLen ?? 0}
-          unstakeAllAmount={unstakeAllAmount}
+          isUnstakeAll={isUnstakeAll}
         />
       }
     </Motion>


### PR DESCRIPTION
because stakeAmount is rounded while showing  to user hence to find if chill is needed we change the condition to use the boolean value of isUnstakeAll boolean value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the `Review` and `Index` components in the staking/unstake section by utilizing custom hooks for data retrieval, improving code readability and maintainability.
	- Introduced a new state variable `isUnstakeAll` to better handle unstaking scenarios.
	- Improved error handling within the `unstake` function.
- **Bug Fixes**
	- Fixed the calculation of `totalAfterUnstake` to handle `decimal` being undefined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->