### PR TITLE
Fix Last Era Redeem Date Issue 

### DIFF
--- a/packages/extension-polkagate/src/popup/staking/solo/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/index.tsx
@@ -129,8 +129,7 @@ export default function Index(): React.ReactElement {
           const amount = new BN(value as unknown as string);
 
           unlockingValue = unlockingValue.add(amount);
-
-          const secToBeReleased = (Number(remainingEras) * sessionInfo.eraLength + (sessionInfo.eraLength - sessionInfo.eraProgress)) * 6;
+          const secToBeReleased = (Number(remainingEras.subn(1)) * sessionInfo.eraLength + (sessionInfo.eraLength - sessionInfo.eraProgress)) * 6;
 
           toBeReleased.push({ amount, date: Date.now() + (secToBeReleased * 1000) });
         }


### PR DESCRIPTION
It seems the time to redeem unstaked amount in solo staking is not correct, It seems this change will fix it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the calculation for the time until funds are released in the staking section to provide more accurate information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->