### PR TITLE
Add a gap between history detail items

### DIFF
--- a/packages/extension-polkagate/src/popup/history/index.tsx
+++ b/packages/extension-polkagate/src/popup/history/index.tsx
@@ -284,7 +284,7 @@ export default function TransactionHistory(): React.ReactElement<''> {
           }
         </Tabs>
       </Box>
-      <Grid container item sx={{ height: '70%', maxHeight: window.innerHeight - 145, overflowY: 'auto', px: '15px' }} xs={12}>
+      <Grid container item sx={{ gap: '5px', height: '70%', maxHeight: window.innerHeight - 145, overflowY: 'auto', px: '15px' }} xs={12}>
         {Object.keys(grouped).length !== 0
           ? <>
             {Object.entries(grouped)?.map((group) => {


### PR DESCRIPTION
Add a gap between history detail items.

before: 
![image](https://github.com/PolkaGate/polkagate-extension/assets/75857984/8cc20871-e923-4a29-bd34-9da4e7a74f53)

now:
![image](https://github.com/PolkaGate/polkagate-extension/assets/75857984/7dcd31c7-dfdc-43ab-a68c-343e77f5fe4b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved spacing in the transaction history view with adjusted gaps for better visual separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->