### PR TITLE
Fix enabling testnet issue

### DIFF
--- a/packages/extension-polkagate/src/partials/Menu.tsx
+++ b/packages/extension-polkagate/src/partials/Menu.tsx
@@ -111,7 +111,6 @@ function Menu({ setShowMenu, theme }: Props): React.ReactElement<Props> {
       window.localStorage.setItem('testnet_enabled', 'false');
       accounts?.forEach(({ address, genesisHash }) => {
         if (genesisHash && TEST_NETS.includes(genesisHash)) {
-          console.log('here');
           tieAccount(address, null).catch(console.error);
         }
       });

--- a/packages/extension-polkagate/src/partials/Menu.tsx
+++ b/packages/extension-polkagate/src/partials/Menu.tsx
@@ -11,11 +11,13 @@ import { keyframes, Theme } from '@mui/material/styles';
 import React, { useCallback, useContext, useState } from 'react';
 
 import { riot } from '../assets/icons';
-import { ActionContext, MenuItem, TwoButtons, Warning } from '../components';
+import { AccountContext, ActionContext, MenuItem, TwoButtons, Warning } from '../components';
 import { useManifest, useTranslation } from '../hooks';
 import ImportAccSubMenu from './ImportAccSubMenu';
 import NewAccountSubMenu from './NewAccountSubMenu';
 import SettingSubMenu from './SettingSubMenu';
+import { tieAccount } from '../messaging';
+import { TEST_NETS } from '../util/constants';
 
 interface Props {
   theme: Theme;
@@ -62,6 +64,7 @@ function Menu({ setShowMenu, theme }: Props): React.ReactElement<Props> {
   const [isTestnetEnabled, setIsTestnetEnabled] = useState<boolean>();
   const [showWarning, setShowWarning] = useState<boolean>();
   const [closeMenu, setCloseMenu] = useState<boolean>(false);
+  const { accounts } = useContext(AccountContext);
 
   const toggleImportSubMenu = useCallback(() => {
     collapsedMenu === COLLAPSIBLE_MENUS.IMPORT_ACCOUNT
@@ -106,9 +109,15 @@ function Menu({ setShowMenu, theme }: Props): React.ReactElement<Props> {
 
     if (isTestnetEnabled) {
       window.localStorage.setItem('testnet_enabled', 'false');
+      accounts?.forEach(({ address, genesisHash }) => {
+        if (genesisHash && TEST_NETS.includes(genesisHash)) {
+          console.log('here');
+          tieAccount(address, null).catch(console.error);
+        }
+      });
       setIsTestnetEnabled(false);
     }
-  }, [isTestnetEnabled]);
+  }, [accounts, isTestnetEnabled]);
 
   const slideLeft = keyframes`
   0% {

--- a/packages/extension-polkagate/src/partials/Menu.tsx
+++ b/packages/extension-polkagate/src/partials/Menu.tsx
@@ -13,11 +13,11 @@ import React, { useCallback, useContext, useState } from 'react';
 import { riot } from '../assets/icons';
 import { AccountContext, ActionContext, MenuItem, TwoButtons, Warning } from '../components';
 import { useManifest, useTranslation } from '../hooks';
+import { tieAccount } from '../messaging';
+import { TEST_NETS } from '../util/constants';
 import ImportAccSubMenu from './ImportAccSubMenu';
 import NewAccountSubMenu from './NewAccountSubMenu';
 import SettingSubMenu from './SettingSubMenu';
-import { tieAccount } from '../messaging';
-import { TEST_NETS } from '../util/constants';
 
 interface Props {
   theme: Theme;

--- a/packages/extension-polkagate/src/partials/SettingSubMenu.tsx
+++ b/packages/extension-polkagate/src/partials/SettingSubMenu.tsx
@@ -13,12 +13,12 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 
 import settings from '@polkadot/ui-settings';
 
-import { AccountContext, ActionContext, Checkbox2, ColorContext, Infotip2, MenuItem, Select, Switch } from '../components';
+import { ActionContext, Checkbox2, ColorContext, Infotip2, MenuItem, Select, Switch } from '../components';
 import { updateStorage } from '../components/Loading';
 import { useExtensionLockContext } from '../context/ExtensionLockContext';
 import { useIsLoginEnabled, useIsPopup, useTranslation } from '../hooks';
-import { lockExtension, setNotification, tieAccount, windowOpen } from '../messaging';
-import { NO_PASS_PERIOD, TEST_NETS } from '../util/constants';
+import { lockExtension, setNotification, windowOpen } from '../messaging';
+import { NO_PASS_PERIOD } from '../util/constants';
 import getLanguageOptions from '../util/getLanguageOptions';
 import { DropdownOption } from '../util/types';
 
@@ -58,7 +58,6 @@ export default function SettingSubMenu({ isTestnetEnabled, onChange, setIsTestne
   const isLoginEnabled = useIsLoginEnabled();
   const onAction = useContext(ActionContext);
   const colorMode = useContext(ColorContext);
-  const { accounts } = useContext(AccountContext);
   const { setExtensionLock } = useExtensionLockContext();
 
   const [notification, updateNotification] = useState(settings.notification);
@@ -76,18 +75,6 @@ export default function SettingSubMenu({ isTestnetEnabled, onChange, setIsTestne
   useEffect(() => {
     settings.set({ camera: camera ? 'on' : 'off' });
   }, [camera]);
-
-  useEffect(() => {
-    const isTestnetDisabled = window.localStorage.getItem('testnet_enabled') !== 'true';
-
-    isTestnetDisabled && (
-      accounts?.forEach(({ address, genesisHash }) => {
-        if (genesisHash && TEST_NETS.includes(genesisHash)) {
-          tieAccount(address, null).catch(console.error);
-        }
-      })
-    );
-  }, [accounts]);
 
   const prefixOptions = settings.availablePrefixes
     .filter(({ value }) => value !== -1)

--- a/packages/extension-polkagate/src/popup/home/AccountPreview.tsx
+++ b/packages/extension-polkagate/src/popup/home/AccountPreview.tsx
@@ -48,8 +48,10 @@ export default function AccountPreview({ address, genesisHash, hideNumbers, isHi
   const _judgement = identity && JSON.stringify(identity.judgements).match(/reasonable|knownGood/gi);
 
   useEffect((): void => {
+    const isTestnetDisabled = window.localStorage.getItem('testnet_enabled') !== 'true';
+
     // eslint-disable-next-line no-void
-    api && api.query?.recovery && api.query.recovery.recoverable(formatted).then((r) => r.isSome && setRecoverable(r.unwrap()));
+    api && !isTestnetDisabled && api.query?.recovery && api.query.recovery.recoverable(formatted).then((r) => r.isSome && setRecoverable(r.unwrap()));
   }, [api, formatted]);
 
   useEffect((): void => {

--- a/packages/extension-polkagate/src/popup/home/AccountPreview.tsx
+++ b/packages/extension-polkagate/src/popup/home/AccountPreview.tsx
@@ -48,10 +48,7 @@ export default function AccountPreview({ address, genesisHash, hideNumbers, isHi
   const _judgement = identity && JSON.stringify(identity.judgements).match(/reasonable|knownGood/gi);
 
   useEffect((): void => {
-    const isTestnetDisabled = window.localStorage.getItem('testnet_enabled') !== 'true';
-
-    // eslint-disable-next-line no-void
-    api && !isTestnetDisabled && api.query?.recovery && api.query.recovery.recoverable(formatted).then((r) => r.isSome && setRecoverable(r.unwrap()));
+    api && api.query?.recovery && api.query.recovery.recoverable(formatted).then((r) => setRecoverable(!!r.isSome));
   }, [api, formatted]);
 
   useEffect((): void => {

--- a/packages/extension-polkagate/src/popup/home/index.tsx
+++ b/packages/extension-polkagate/src/popup/home/index.tsx
@@ -31,7 +31,6 @@ export default function Home(): React.ReactElement {
   const { t } = useTranslation();
   const { accounts, hierarchy } = useContext(AccountContext);
   const theme = useTheme();
-  const isTestnetEnabled = useIsTestnetEnabled();
 
   useMerkleScience(undefined, undefined, true); // to download the data file
 
@@ -41,16 +40,6 @@ export default function Home(): React.ReactElement {
   const [hasActiveRecovery, setHasActiveRecovery] = useState<string | null | undefined>(); // if exists, include the account address
   const [loginInfo, setLoginInfo] = useState<LoginInfo>();
   const [bgImage, setBgImage] = useState<string | undefined>();
-
-  useEffect(() => {
-    !isTestnetEnabled && (
-      accounts?.forEach(({ address, genesisHash }) => {
-        if (genesisHash && TEST_NETS.includes(genesisHash)) {
-          tieAccount(address, null).catch(console.error);
-        }
-      })
-    );
-  }, [accounts, isTestnetEnabled]);
 
   useEffect(() => {
     const value = window.localStorage.getItem('inUse_version');

--- a/packages/extension-polkagate/src/popup/home/index.tsx
+++ b/packages/extension-polkagate/src/popup/home/index.tsx
@@ -16,10 +16,10 @@ import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 import { AccountContext, Warning } from '../../components';
 import { getStorage, LoginInfo } from '../../components/Loading';
-import { useIsTestnetEnabled, useMerkleScience, useTranslation } from '../../hooks';
-import { tieAccount, windowOpen } from '../../messaging';
+import { useMerkleScience, useTranslation } from '../../hooks';
+import { windowOpen } from '../../messaging';
 import HeaderBrand from '../../partials/HeaderBrand';
-import { NEW_VERSION_ALERT, TEST_NETS } from '../../util/constants';
+import { NEW_VERSION_ALERT } from '../../util/constants';
 import Welcome from '../welcome';
 import Reset from '../welcome/Reset';
 import AccountsTree from './AccountsTree';
@@ -27,9 +27,9 @@ import AiBackgroundImage from './AiBackgroundImage';
 import Alert from './Alert';
 import YouHave from './YouHave';
 
-export default function Home(): React.ReactElement {
+export default function Home (): React.ReactElement {
   const { t } = useTranslation();
-  const { accounts, hierarchy } = useContext(AccountContext);
+  const { hierarchy } = useContext(AccountContext);
   const theme = useTheme();
 
   useMerkleScience(undefined, undefined, true); // to download the data file


### PR DESCRIPTION
## Works Done

1. Remove unnecessary useEffect on `packages/extension-polkagate/src/popup/home/index.tsx`
2. Remove unnecessary useEffect on `packages/extension-polkagate/src/partials/SettingSubMenu.tsx`
3. Switch the account networks to any chains when the associated test nets are not enabled on `packages/extension-polkagate/src/partials/Menu.tsx`.
4. Prevent of happening an error on `packages/extension-polkagate/src/popup/home/AccountPreview.tsx`.

Close #916 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated account tie-in functionality within the menu for enhanced user interaction.
  - Implemented conditional test network features, improving user control over network preferences.

- **Bug Fixes**
  - Refined settings update mechanisms, ensuring more reliable user experience.
  - Adjusted account preview logic to respect user-selected network settings.

- **Refactor**
  - Streamlined network state management across various components for increased app performance and maintainability.
  - Updated background image handling for better visual customization.

- **Chores**
  - Removed outdated code and dependencies to clean up the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->